### PR TITLE
Implement optional Redis storage and forwarding for ReportServer

### DIFF
--- a/python/WIP_Server/servers/report_server/config.ini
+++ b/python/WIP_Server/servers/report_server/config.ini
@@ -45,3 +45,16 @@ log_redis_db = ${LOG_REDIS_DB}
 [database]
 # データベース設定
 enable_database = false
+
+[redis]
+# Redis保存設定
+enable_redis = false
+host = ${REDIS_HOST}
+port = ${REDIS_PORT}
+db = ${REDIS_DB}
+
+[forward]
+# レポート転送先サーバー設定
+enable_forward = false
+host = ${REPORT_FORWARD_HOST}
+port = ${REPORT_FORWARD_PORT}


### PR DESCRIPTION
## Summary
- extend `ReportServer` with optional Redis save and forwarding features
- add related configuration options in `config.ini`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6882dce5be5083228d28784197859ba2