### PR TITLE
Move update logic to ReportServer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ license = { text = "MIT" }
 authors = [{ name = "WIP Team", email = "u22.wip.team@gmail.com" }]
 requires-python = ">=3.9"
 dependencies = [
-    "requests>=2.32.0"
+    "requests>=2.32.0",
+    "schedule>=1.2.0"
 ]
 classifiers = [
   "Programming Language :: Python :: 3",

--- a/python/WIP_Server/data/get_alert.py
+++ b/python/WIP_Server/data/get_alert.py
@@ -2,7 +2,7 @@
 警報・注意報情報取得スクリプト
 
 リファクタリング済みのAlertProcessorを使用して
-警報・注意報情報を取得・処理し、Redisに格納します。
+警報・注意報情報を取得・処理し、必要に応じてRedisに格納します。
 
 使用方法:
     python get_alert.py
@@ -17,7 +17,7 @@ from WIP_Server.data.alert_processor import AlertDataProcessor, AlertProcessor
 from WIP_Server.data.redis_manager import create_redis_manager
 JSON_DIR = Path(__file__).resolve().parents[2] / "logs" / "json"
 
-def main():
+def main(save_to_redis=True):
     """
     警報・注意報処理のメイン関数
     
@@ -45,33 +45,28 @@ def main():
         
         print("\n=== 警報・注意報情報取得完了===")
         
-        # Redis管理クラスを使用してデータを更新
-        print("\n=== Redisデータ更新開始 ===")
-        
-        try:
-            # Redis管理クラスのインスタンスを作成
-            redis_manager = create_redis_manager(debug=True)
-            
-            # 警報・注意報情報を更新
-            # RedisManagerのupdate_alertsはarea_alert_mapping部分を期待
-            result = redis_manager.update_alerts(json_result)
-            
-            # 結果を表示
-            print(f"\n=== Redis更新結果 ===")
-            print(f"更新されたエリア: {result['updated']}件")
-            print(f"新規作成されたエリア: {result['created']}件")
-            print(f"エラー: {result['errors']}件")
-            print(f"合計処理エリア: {result['updated'] + result['created']}件")
-            
-            # 接続を閉じる
-            redis_manager.close()
-            
-            print("=== Redisデータ更新完了 ===")
-            
-        except Exception as e:
-            print(f"Redis更新エラー: {e}")
+        if save_to_redis:
+            # Redis管理クラスを使用してデータを更新
+            print("\n=== Redisデータ更新開始 ===")
+            try:
+                redis_manager = create_redis_manager(debug=True)
+                result = redis_manager.update_alerts(json_result)
+
+                print(f"\n=== Redis更新結果 ===")
+                print(f"更新されたエリア: {result['updated']}件")
+                print(f"新規作成されたエリア: {result['created']}件")
+                print(f"エラー: {result['errors']}件")
+                print(f"合計処理エリア: {result['updated'] + result['created']}件")
+
+                redis_manager.close()
+                print("=== Redisデータ更新完了 ===")
+
+            except Exception as e:
+                print(f"Redis更新エラー: {e}")
     except Exception as e:
         print(f"Error in alert processing: {e}")
+
+    return json_result
 
 
 if __name__ == "__main__":

--- a/python/WIP_Server/scripts/update_alert_disaster_data.py
+++ b/python/WIP_Server/scripts/update_alert_disaster_data.py
@@ -5,15 +5,15 @@ import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 from WIP_Server.data import get_alert,get_unified_data
 
-def main():
+def main(save_to_redis=True):
     print("alert処理開始")
     try:
-        get_alert.main()
+        get_alert.main(save_to_redis=save_to_redis)
     except Exception as e:
         print(f"Error calling get_alert.main: {e}")
     print("統合災害・地震処理開始")
     try:
-        get_unified_data.main()
+        get_unified_data.main(save_to_redis=save_to_redis)
     except Exception as e:
         print(f"Error calling get_unified_data.main: {e}")
     print("処理完了")

--- a/python/WIP_Server/servers/report_server/config.ini
+++ b/python/WIP_Server/servers/report_server/config.ini
@@ -45,3 +45,7 @@ log_redis_db = ${LOG_REDIS_DB}
 [database]
 # データベース設定
 enable_database = false
+[schedule]
+weather_update_time = 05:00, 11:00, 17:00
+disaster_alert_update_time = 10
+


### PR DESCRIPTION
## Summary
- fetch weather data to JSON via new helper
- allow alert/disaster scripts to skip Redis
- move update tasks from `QueryServer` to `ReportServer`
- add schedule section to report server config
- add `schedule` dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_6882decb01008322a7814d8a7bc6129e