### PR TITLE
MITライセンスを明示

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 WIP Project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -472,32 +472,7 @@ python debug_tools/performance/performance_debug_tool.py
 - **サーバエラー**: 適切なエラーコード返送
 
 ## ライセンス
-
-このプロジェクトはMITライセンスの下で公開されています。
-
-```
-MIT License
-
-Copyright (c) 2025 WIP Project
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
+このプロジェクトはMITライセンスの下で公開されています。詳しくは [LICENSE](LICENSE) をご覧ください。
 
 ## 貢献
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name            = "wiplib"            # ← パッケージ名はそのまま
 version         = "0.1.0"
 description     = "Awesome toolkit for weather data (client‑side)."
 readme          = "README.md"
-license         = { text = "MIT" }
+license = { file = "LICENSE" }
 authors         = [{ name = "WIP Team", email = "u22.wip.team@gmail.com" }]
 requires-python = ">=3.9"
 


### PR DESCRIPTION
## 概要
- リポジトリ直下に `LICENSE` を追加し、MIT ライセンスを明示しました
- `pyproject.toml` で `license` フィールドを `LICENSE` ファイル参照に更新しました
- README のライセンス記載を簡潔化し、`LICENSE` へのリンクを追加しました

## テスト
- `pip install -r requirements.txt`
- `pip install pytest pytest-asyncio pytest-cov pytest-xdist`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882f9a747a08324ac460e030b7ea058