### PR TITLE
パッケージデータの登録を追加

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,11 @@ include = [
     "WIPCommonPy*",
     "WIPServerPy*",
 ]  # 各サーバーパッケージも含める
+
+[tool.setuptools.package-data]
+"WIPClientPy" = ["config.ini", "coordinate_cache.json"]
+"WIPCommonPy.packet.format_spec" = ["*.json"]
+"WIPServerPy.servers.location_server" = ["config.ini"]
+"WIPServerPy.servers.query_server" = ["config.ini"]
+"WIPServerPy.servers.weather_server" = ["config.ini"]
+"WIPServerPy.servers.report_server" = ["config.ini"]


### PR DESCRIPTION
## 変更内容
- `pyproject.toml` の `tool.setuptools.package-data` を設定し、設定ファイルや JSON 定義ファイルを wheel に含めるよう調整

## 確認内容
- `python -m build` で生成した wheel に `config.ini` や `coordinate_cache.json` 等が含まれることを確認
- `pytest` 実行で 23 件のテストが成功


------
https://chatgpt.com/codex/tasks/task_e_6882f9adfa9083249f0c5e0d92685b2a