### PR TITLE
Update redis timestamp handling

### DIFF
--- a/python/WIP_Server/scripts/update_weather_data.py
+++ b/python/WIP_Server/scripts/update_weather_data.py
@@ -227,13 +227,13 @@ def get_data(area_codes: list, debug=False, save_to_redis=False):
             
             # weather_reportdatetime を output から分離
             report_datetimes_data = output.pop("weather_reportdatetime", {})
-            
-            # エリアごとの気象データを一括保存
-            result = redis_manager.bulk_update_weather_data(output)
-            
-            # weather_reportdatetime を個別に保存
-            if report_datetimes_data:
-                redis_manager.update_weather_data("weather_reportdatetime", report_datetimes_data)
+
+            # エリアごとの気象データとreportdatetimeを一括保存
+            result = redis_manager.bulk_update_weather_data(
+                output,
+                report_datetimes=report_datetimes_data,
+            )
+
 
             redis_manager.close()
 

--- a/python/WIP_Server/servers/report_server/report_server.py
+++ b/python/WIP_Server/servers/report_server/report_server.py
@@ -429,6 +429,19 @@ class ReportServer(BaseServer):
         try:
             key = f"report:{sensor_data['area_code']}"
             self.redis_client.json().set(key, ".", sensor_data)
+
+            # weather系データが含まれる場合はweather_reportdatetimeも更新
+            if any(k in sensor_data for k in ("weather_code", "temperature", "precipitation_prob")):
+                ts = sensor_data.get("timestamp")
+                if isinstance(ts, int):
+                    dt = datetime.fromtimestamp(ts).isoformat()
+                else:
+                    dt = str(ts)
+                self.redis_client.json().set(
+                    "weather_reportdatetime",
+                    f".{sensor_data['area_code']}",
+                    dt,
+                )
             if self.debug:
                 print(f"  ✓ Redisに保存: {key}")
         except Exception as e:


### PR DESCRIPTION
## Summary
- update Redis manager to record `weather_reportdatetime` when weather data changes
- extend bulk update to set report datetimes
- adjust weather update script to pass report times
- store latest weather report timestamp from report server data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6882e63420748322ae639c678e785ce3