### PR TITLE
[pypi] add all extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ pip install -e .[query_server]
 
 # すべてのサーバーをインストールする場合
 pip install -e .[servers]
+
+# PyPI から全機能をインストールする場合
+pip install "wiplib[all]"
 ```
 
 ### 環境変数設定

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,18 @@ servers = [
     "python-dateutil",
     "python-dotenv",
 ]
+all = [
+    "psycopg2",
+    "redis",
+    "schedule",
+    "python-dateutil",
+    "python-dotenv",
+    "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
+    "pytest-xdist",
+    "black",
+]
 
 # ─── どのソースを wheel に含めるか ────────────
 [tool.setuptools]


### PR DESCRIPTION
## 変更点
- `pyproject.toml` に `all` オプションを追加し、全依存を一括インストールできるようにしました
- README に `pip install "wiplib[all]"` の例を追記

## テスト
- `pytest -q` が成功することを確認

------
https://chatgpt.com/codex/tasks/task_e_6888dbf87dc08324907d328fb77a9053