### PR TITLE
Add per-server auth config flags and global toggle

### DIFF
--- a/cpp/include/wiplib/client/auth_config.hpp
+++ b/cpp/include/wiplib/client/auth_config.hpp
@@ -6,7 +6,11 @@
 namespace wiplib::client {
 
 struct AuthConfig {
-    bool enabled = false;
+    bool enabled = false; // global switch via WIP_CLIENT_AUTH_ENABLED
+    bool weather_request_auth_enabled = false;
+    bool location_resolver_request_auth_enabled = false;
+    bool query_generator_request_auth_enabled = false;
+    bool report_server_request_auth_enabled = false;
     bool verify_response = false; // optional, default off
     std::optional<std::string> weather{};
     std::optional<std::string> location{};


### PR DESCRIPTION
## Summary
- read per-server auth enable flags from environment variables
- support global WIP_CLIENT_AUTH_ENABLED for all servers
- remove leftover debug prints

## Testing
- `cmake -S cpp -B build` *(fails: Cannot find source file: src/packet/debug/debug_logger.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ea4b7e808322a6c0b033a748505a