### PR TITLE
ClientとClientAsyncにset_area_codeを追加

### DIFF
--- a/cpp/include/wiplib/client/client.hpp
+++ b/cpp/include/wiplib/client/client.hpp
@@ -59,6 +59,9 @@ public:
   // 座標設定
   void set_coordinates(double lat, double lon);
 
+  // エリアコード設定
+  void set_area_code(std::string area_code);
+
   // サーバ設定（Pythonと同名）
   void set_server(const std::string& host);
   void set_server(const std::string& host, uint16_t port);

--- a/cpp/include/wiplib/client/client_async.hpp
+++ b/cpp/include/wiplib/client/client_async.hpp
@@ -44,6 +44,9 @@ public:
     // 座標設定
     void set_coordinates(double lat, double lon);
 
+    // エリアコード設定
+    void set_area_code(std::string area_code);
+
     // 非同期天気データ取得
     std::future<Result<WeatherData>> get_weather(
         bool weather = true,

--- a/cpp/src/client/client.cpp
+++ b/cpp/src/client/client.cpp
@@ -1,6 +1,7 @@
 #include "wiplib/client/client.hpp"
 #include "wiplib/error.hpp"
 #include <stdexcept>
+#include <utility>
 
 namespace wiplib::client {
 
@@ -64,6 +65,13 @@ void Client::set_coordinates(double lat, double lon) {
     state_.longitude = lon;
     if (wip_client_) {
         wip_client_->set_coordinates(lat, lon);
+    }
+}
+
+void Client::set_area_code(std::string area_code) {
+    state_.area_code = area_code;
+    if (wip_client_) {
+        wip_client_->set_area_code(std::move(area_code));
     }
 }
 

--- a/cpp/src/client/client_async.cpp
+++ b/cpp/src/client/client_async.cpp
@@ -1,6 +1,7 @@
 #include "wiplib/client/client_async.hpp"
 #include "wiplib/error.hpp"
 #include <stdexcept>
+#include <utility>
 
 namespace wiplib::client {
 
@@ -68,6 +69,14 @@ void ClientAsync::set_coordinates(double lat, double lon) {
     state_.longitude = lon;
     if (wip_client_) {
         wip_client_->set_coordinates(lat, lon);
+    }
+}
+
+void ClientAsync::set_area_code(std::string area_code) {
+    std::lock_guard<std::mutex> lock(async_mutex_);
+    state_.area_code = area_code;
+    if (wip_client_) {
+        wip_client_->set_area_code(std::move(area_code));
     }
 }
 


### PR DESCRIPTION
## 概要
- Clientクラスに`set_area_code`メソッドを追加
- ClientAsyncにも同等の`set_area_code`を実装

## テスト
- `cmake -S cpp -B cpp/build` (src/packet/debug/debug_logger.cppが見つからず失敗)

------
https://chatgpt.com/codex/tasks/task_e_68a3ea5ac9088322b57be7ddb0a7d6c2