### PR TITLE
Enable precipitation probability by default

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -39,7 +39,7 @@ using namespace wiplib::client;
 
 int main(){
   WeatherClient cli("127.0.0.1", 4110);
-  QueryOptions opt;  // weather/temperature=on,他は必要に応じて
+  QueryOptions opt;  // weather/temperature/precipitation_prob=on,他は必要に応じて
   auto res = cli.get_weather_by_area_code("011000", opt);
   if(!res){ /* エラー処理 */ return 1; }
   const auto& r = res.value();

--- a/cpp/include/wiplib/client/weather_client.hpp
+++ b/cpp/include/wiplib/client/weather_client.hpp
@@ -14,7 +14,7 @@ namespace wiplib::client {
 struct QueryOptions {
   bool weather = true;
   bool temperature = true;
-  bool precipitation_prob = false;
+  bool precipitation_prob = true;
   bool alerts = false;
   bool disaster = false;
   uint8_t day = 0;

--- a/cpp/tests/integration/test_weather_client.cpp
+++ b/cpp/tests/integration/test_weather_client.cpp
@@ -54,7 +54,7 @@ TEST_F(WeatherClientIntegrationTest, QueryOptionsConfiguration) {
     // デフォルト値の確認
     EXPECT_TRUE(options.weather);
     EXPECT_TRUE(options.temperature);
-    EXPECT_FALSE(options.precipitation_prob);
+    EXPECT_TRUE(options.precipitation_prob);
     EXPECT_FALSE(options.alerts);
     EXPECT_FALSE(options.disaster);
     EXPECT_EQ(options.day, 0);

--- a/cpp/tools/wip_client_cli.cpp
+++ b/cpp/tools/wip_client_cli.cpp
@@ -36,7 +36,7 @@ static void print_usage() {
                "Flags:\n"
                "  --weather (default on), --no-weather\n"
                "  --temperature (default on), --no-temperature\n"
-               "  --precipitation, --alerts, --disaster\n"
+               "  --precipitation (default on), --no-precipitation, --alerts, --disaster\n"
                "  --day <0-7>\n"
                "  --location-host H, --location-port P (direct mode)\n"
                "  --query-host H, --query-port P (direct mode)\n"
@@ -81,6 +81,8 @@ static bool parse_args(int argc, char** argv, Args& args) {
       args.opt.temperature = false;
     } else if (a == "--precipitation") {
       args.opt.precipitation_prob = true;
+    } else if (a == "--no-precipitation") {
+      args.opt.precipitation_prob = false;
     } else if (a == "--alerts") {
       args.opt.alerts = true;
     } else if (a == "--disaster") {


### PR DESCRIPTION
## Summary
- enable precipitation probability by default in `QueryOptions`
- update CLI and docs for new default
- adjust tests to expect precipitation probability

## Testing
- `cmake -S cpp -B cpp/build -DCMAKE_BUILD_TYPE=Release` *(fails: Cannot find source file: src/packet/debug/debug_logger.cpp)*
- `g++ -std=c++20 -I cpp/include /tmp/test.cpp -o /tmp/test && /tmp/test && echo "precip true"`

------
https://chatgpt.com/codex/tasks/task_e_68a3ea7a08bc8322a7e845812d24864d