### PR TITLE
Add auth hash attachment in report request

### DIFF
--- a/cpp/src/packet/report_packet_compat.cpp
+++ b/cpp/src/packet/report_packet_compat.cpp
@@ -200,6 +200,15 @@ std::vector<uint8_t> PyReportRequest::to_bytes() const {
     // alert / disaster は拡張フィールドへ
     packet.extensions = build_extended_fields();
 
+    // 認証が有効な場合はハッシュを付与
+    if (auth_enabled && !auth_passphrase.empty()) {
+        if (wiplib::utils::WIPAuth::attach_auth_hash(packet, auth_passphrase)) {
+            // 拡張フィールドと認証フラグが正しく設定されていることを保証
+            packet.header.flags.extended = true;
+            packet.header.flags.auth_enabled = true;
+        }
+    }
+
     auto enc = proto::encode_packet(packet);
     if (enc.has_value()) {
         return enc.value();


### PR DESCRIPTION
## Summary
- Attach authentication hash when serializing report requests
- Ensure extended and auth flags are set after adding auth field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a40258ab188322adf8ee71339e3dd0