### PR TITLE
Add alert and disaster info to weather results

### DIFF
--- a/cpp/include/wiplib/client/weather_client.hpp
+++ b/cpp/include/wiplib/client/weather_client.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <cstdint>
 #include <optional>
+#include <vector>
 
 #include "wiplib/expected.hpp"
 #include "wiplib/error.hpp"
@@ -25,6 +26,8 @@ struct WeatherResult {
   std::optional<uint16_t> weather_code{};
   std::optional<int8_t> temperature{};
   std::optional<uint8_t> precipitation_prob{};
+  std::optional<std::vector<std::string>> alerts{};
+  std::optional<std::vector<std::string>> disasters{};
 };
 
 class WeatherClient {

--- a/cpp/include/wiplib/client/wip_client.hpp
+++ b/cpp/include/wiplib/client/wip_client.hpp
@@ -39,6 +39,8 @@ struct WeatherData {
   std::optional<uint16_t> weather_code{};
   std::optional<int> temperature_c{}; // Celsius
   std::optional<int> precipitation_prob{};
+  std::optional<std::vector<std::string>> alerts{};
+  std::optional<std::vector<std::string>> disasters{};
 };
 
 class WipClient {

--- a/cpp/src/client/client.cpp
+++ b/cpp/src/client/client.cpp
@@ -187,7 +187,7 @@ void Client::initialize_report_client() {
 }
 
 // レポート送信API（SimpleReportClientへの委譲）
-void Client::set_sensor_data(const std::string& area_code, 
+void Client::set_sensor_data(const std::string& area_code,
                             std::optional<int> weather_code,
                             std::optional<float> temperature,
                             std::optional<int> precipitation_prob,
@@ -196,6 +196,7 @@ void Client::set_sensor_data(const std::string& area_code,
     if (!report_client_) {
         initialize_report_client();
     }
+    // 新しい警報・災害情報フィールドもそのまま委譲
     report_client_->set_sensor_data(area_code, weather_code, temperature, precipitation_prob, alert, disaster);
 }
 

--- a/cpp/src/client/query_client.cpp
+++ b/cpp/src/client/query_client.cpp
@@ -2,6 +2,8 @@
 
 #include "wiplib/packet/codec.hpp"
 #include "wiplib/utils/auth.hpp"
+#include "wiplib/packet/extended_field.hpp"
+#include <variant>
 #include <chrono>
 #include <random>
 #include <iostream>
@@ -143,6 +145,16 @@ wiplib::Result<WeatherResult> QueryClient::get_weather_data(std::string_view are
     out.weather_code = rp.response_fields->weather_code;
     out.temperature = rp.response_fields->temperature; // +100オフセットの生値
     out.precipitation_prob = rp.response_fields->precipitation_prob;
+  }
+  if (auto f = packet::ExtendedFieldManager::get_field(rp, packet::ExtendedFieldKey::Alert)) {
+    if (auto v = std::get_if<std::vector<std::string>>(&*f)) {
+      out.alerts = *v;
+    }
+  }
+  if (auto f = packet::ExtendedFieldManager::get_field(rp, packet::ExtendedFieldKey::Disaster)) {
+    if (auto v = std::get_if<std::vector<std::string>>(&*f)) {
+      out.disasters = *v;
+    }
   }
   return out;
 }

--- a/cpp/src/client/simple_report_client.cpp
+++ b/cpp/src/client/simple_report_client.cpp
@@ -148,10 +148,14 @@ void SimpleReportClient::set_sensor_data(
     
     // デバッグ情報の出力（コンソール出力に変更）
     if (debug_) {
-        std::cout << "センサーデータを設定: エリア=" << area_code 
+        std::cout << "センサーデータを設定: エリア=" << area_code
                   << ", 天気=" << (weather_code ? std::to_string(*weather_code) : "null")
                   << ", 気温=" << (temperature ? std::to_string(*temperature) + "℃" : "null")
                   << ", 降水確率=" << (precipitation_prob ? std::to_string(*precipitation_prob) + "%" : "null")
+                  << ", 警報="
+                  << (alert ? std::to_string(alert->size()) : std::string("null"))
+                  << ", 災害="
+                  << (disaster ? std::to_string(disaster->size()) : std::string("null"))
                   << std::endl;
     }
 }

--- a/cpp/src/client/weather_client.cpp
+++ b/cpp/src/client/weather_client.cpp
@@ -2,6 +2,8 @@
 
 #include "wiplib/packet/codec.hpp"
 #include "wiplib/utils/auth.hpp"
+#include "wiplib/packet/extended_field.hpp"
+#include <variant>
 #include <chrono>
 #include <random>
 #include <cstring>
@@ -378,6 +380,16 @@ wiplib::Result<WeatherResult> WeatherClient::request_and_parse(const wiplib::pro
                   result.temperature = rp.response_fields->temperature;
                   result.precipitation_prob = rp.response_fields->precipitation_prob;
                 }
+                if (auto f = packet::ExtendedFieldManager::get_field(rp, packet::ExtendedFieldKey::Alert)) {
+                  if (auto v = std::get_if<std::vector<std::string>>(&*f)) {
+                    result.alerts = *v;
+                  }
+                }
+                if (auto f = packet::ExtendedFieldManager::get_field(rp, packet::ExtendedFieldKey::Disaster)) {
+                  if (auto v = std::get_if<std::vector<std::string>>(&*f)) {
+                    result.disasters = *v;
+                  }
+                }
                 if (result.area_code == 0) result.area_code = rp.header.area_code;
                 // クローズして返す
 #if defined(_WIN32)
@@ -425,6 +437,16 @@ wiplib::Result<WeatherResult> WeatherClient::request_and_parse(const wiplib::pro
                   result.weather_code = rp.response_fields->weather_code;
                   result.temperature = rp.response_fields->temperature;
                   result.precipitation_prob = rp.response_fields->precipitation_prob;
+                }
+                if (auto f = packet::ExtendedFieldManager::get_field(rp, packet::ExtendedFieldKey::Alert)) {
+                  if (auto v = std::get_if<std::vector<std::string>>(&*f)) {
+                    result.alerts = *v;
+                  }
+                }
+                if (auto f = packet::ExtendedFieldManager::get_field(rp, packet::ExtendedFieldKey::Disaster)) {
+                  if (auto v = std::get_if<std::vector<std::string>>(&*f)) {
+                    result.disasters = *v;
+                  }
                 }
 #if defined(_WIN32)
                 closesocket(sock); WSACleanup();

--- a/cpp/src/client/wip_client.cpp
+++ b/cpp/src/client/wip_client.cpp
@@ -94,6 +94,8 @@ Result<WeatherData> WipClient::get_weather_by_coordinates(double lat, double lon
     if (res.value().weather_code) out.weather_code = res.value().weather_code;
     if (res.value().temperature) out.temperature_c = static_cast<int>(*res.value().temperature) - 100; // Python仕様
     if (res.value().precipitation_prob) out.precipitation_prob = static_cast<int>(*res.value().precipitation_prob);
+    if (res.value().alerts) out.alerts = res.value().alerts;
+    if (res.value().disasters) out.disasters = res.value().disasters;
     return out;
   }
   auto ac = resolve_area_code_direct(lat, lon, opt);
@@ -110,6 +112,8 @@ Result<WeatherData> WipClient::get_weather_by_area_code(std::string_view area_co
     if (res.value().weather_code) out.weather_code = res.value().weather_code;
     if (res.value().temperature) out.temperature_c = static_cast<int>(*res.value().temperature) - 100;
     if (res.value().precipitation_prob) out.precipitation_prob = static_cast<int>(*res.value().precipitation_prob);
+    if (res.value().alerts) out.alerts = res.value().alerts;
+    if (res.value().disasters) out.disasters = res.value().disasters;
     return out;
   }
   return query_weather_direct(area_code, opt);
@@ -131,6 +135,8 @@ Result<WeatherData> WipClient::query_weather_direct(std::string_view area_code, 
   if (r.value().weather_code) out.weather_code = r.value().weather_code;
   if (r.value().temperature) out.temperature_c = static_cast<int>(*r.value().temperature) - 100;
   if (r.value().precipitation_prob) out.precipitation_prob = static_cast<int>(*r.value().precipitation_prob);
+  if (r.value().alerts) out.alerts = r.value().alerts;
+  if (r.value().disasters) out.disasters = r.value().disasters;
   return out;
 }
 


### PR DESCRIPTION
## Summary
- Weather APIレスポンスに警報・災害情報(alerts/disasters)を含められるようフィールドを追加
- weather/query/wip クライアントで拡張フィールドから警報・災害情報を解析して転写
- レポートクライアントや上位Clientで新フィールドを受け渡し

## Testing
- `cmake -S cpp -B build -DWIPLIB_BUILD_TESTS=ON` *(failed: CONNECT tunnel failed, response 403)*
- `cmake -S cpp -B build -DWIPLIB_BUILD_TESTS=OFF` *(failed: Cannot find source file: src/packet/debug/debug_logger.cpp)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a412fd8fb48322a9943688bb246900