### PR TITLE
feat: selectable report destination for report client

### DIFF
--- a/cpp/include/wiplib/client/client.hpp
+++ b/cpp/include/wiplib/client/client.hpp
@@ -128,16 +128,21 @@ public:
   void set_alert(const std::vector<std::string>& alert);
   void set_disaster(const std::vector<std::string>& disaster);
   
-  Result<ReportResult> send_report_data();
-  std::future<Result<ReportResult>> send_report_data_async();
-  Result<ReportResult> send_data_simple();
+  Result<ReportResult> send_report_data(bool proxy = false,
+                                        std::optional<ServerConfig> report_server = std::nullopt);
+  std::future<Result<ReportResult>> send_report_data_async(bool proxy = false,
+                                                           std::optional<ServerConfig> report_server = std::nullopt);
+  Result<ReportResult> send_data_simple(bool proxy = false,
+                                        std::optional<ServerConfig> report_server = std::nullopt);
   
   std::unordered_map<std::string, std::any> get_current_data() const;
   void clear_data();
   
   // 後方互換性メソッド
-  Result<ReportResult> send_report();
-  Result<ReportResult> send_current_data();
+  Result<ReportResult> send_report(bool proxy = false,
+                                   std::optional<ServerConfig> report_server = std::nullopt);
+  Result<ReportResult> send_current_data(bool proxy = false,
+                                         std::optional<ServerConfig> report_server = std::nullopt);
 
   // RAII サポート（Python with相当）
   Client& operator()() { return *this; } // __enter__ equivalent
@@ -157,7 +162,8 @@ private:
                               bool alert, bool disaster, uint8_t day) const;
   void validate_port() const;
   void initialize_wip_client();
-  void initialize_report_client();
+  void initialize_report_client(bool proxy = false,
+                                std::optional<ServerConfig> report_server = std::nullopt);
 };
 
 } // namespace wiplib::client

--- a/cpp/include/wiplib/client/simple_report_client.hpp
+++ b/cpp/include/wiplib/client/simple_report_client.hpp
@@ -99,12 +99,25 @@ public:
      * @param alert 警報情報リスト
      */
     void set_alert(const std::vector<std::string>& alert);
-    
+
     /**
      * @brief 災害情報を設定（Python版set_disaster()互換）
      * @param disaster 災害情報リスト
      */
     void set_disaster(const std::vector<std::string>& disaster);
+
+    /**
+     * @brief 接続先サーバーを再設定
+     * @param host ホスト名
+     * @param port ポート番号
+     */
+    void set_server(const std::string& host, uint16_t port);
+
+    /**
+     * @brief 接続先サーバーを再設定（ポートは保持）
+     * @param host ホスト名
+     */
+    void set_server(const std::string& host);
     
     // Python互換送信API
     

--- a/cpp/src/client/client.cpp
+++ b/cpp/src/client/client.cpp
@@ -2,6 +2,7 @@
 #include "wiplib/error.hpp"
 #include <stdexcept>
 #include <utility>
+#include <cstdlib>
 
 namespace wiplib::client {
 
@@ -182,8 +183,26 @@ void Client::initialize_wip_client() {
     }
 }
 
-void Client::initialize_report_client() {
-    report_client_ = std::make_unique<SimpleReportClient>(config_.host, config_.port, debug_);
+void Client::initialize_report_client(bool proxy, std::optional<ServerConfig> report_server) {
+    std::string host;
+    uint16_t port;
+    if (report_server.has_value()) {
+        host = report_server->host;
+        port = report_server->port;
+    } else if (proxy) {
+        host = config_.host;
+        port = config_.port;
+    } else {
+        const char* env_host = std::getenv("REPORT_SERVER_HOST");
+        host = env_host ? env_host : "127.0.0.1";
+        const char* env_port = std::getenv("REPORT_SERVER_PORT");
+        port = env_port ? static_cast<uint16_t>(std::atoi(env_port)) : 4112;
+    }
+    if (report_client_) {
+        report_client_->set_server(host, port);
+    } else {
+        report_client_ = std::make_unique<SimpleReportClient>(host, port, debug_);
+    }
 }
 
 // レポート送信API（SimpleReportClientへの委譲）
@@ -246,24 +265,21 @@ void Client::set_disaster(const std::vector<std::string>& disaster) {
     report_client_->set_disaster(disaster);
 }
 
-Result<ReportResult> Client::send_report_data() {
-    if (!report_client_) {
-        initialize_report_client();
-    }
+Result<ReportResult> Client::send_report_data(bool proxy,
+                                             std::optional<ServerConfig> report_server) {
+    initialize_report_client(proxy, report_server);
     return report_client_->send_report_data();
 }
 
-std::future<Result<ReportResult>> Client::send_report_data_async() {
-    if (!report_client_) {
-        initialize_report_client();
-    }
+std::future<Result<ReportResult>> Client::send_report_data_async(
+    bool proxy, std::optional<ServerConfig> report_server) {
+    initialize_report_client(proxy, report_server);
     return report_client_->send_report_data_async();
 }
 
-Result<ReportResult> Client::send_data_simple() {
-    if (!report_client_) {
-        initialize_report_client();
-    }
+Result<ReportResult> Client::send_data_simple(bool proxy,
+                                              std::optional<ServerConfig> report_server) {
+    initialize_report_client(proxy, report_server);
     return report_client_->send_data_simple();
 }
 
@@ -281,18 +297,14 @@ void Client::clear_data() {
     report_client_->clear_data();
 }
 
-Result<ReportResult> Client::send_report() {
-    if (!report_client_) {
-        initialize_report_client();
-    }
-    return report_client_->send_report();
+Result<ReportResult> Client::send_report(bool proxy,
+                                         std::optional<ServerConfig> report_server) {
+    return send_report_data(proxy, report_server);
 }
 
-Result<ReportResult> Client::send_current_data() {
-    if (!report_client_) {
-        initialize_report_client();
-    }
-    return report_client_->send_current_data();
+Result<ReportResult> Client::send_current_data(bool proxy,
+                                               std::optional<ServerConfig> report_server) {
+    return send_data_simple(proxy, report_server);
 }
 
 } // namespace wiplib::client

--- a/cpp/src/client/simple_report_client.cpp
+++ b/cpp/src/client/simple_report_client.cpp
@@ -180,6 +180,36 @@ void SimpleReportClient::set_disaster(const std::vector<std::string>& disaster) 
     disaster_ = disaster;
 }
 
+void SimpleReportClient::set_server(const std::string& host, uint16_t port) {
+    close();
+    host_ = host;
+    port_ = port;
+
+    if (host_ == "localhost") {
+        const char* env_host = std::getenv("REPORT_SERVER_HOST");
+        if (env_host) {
+            host_ = env_host;
+        }
+    }
+    if (port_ == 4112) {
+        const char* env_port = std::getenv("REPORT_SERVER_PORT");
+        if (env_port) {
+            port_ = static_cast<uint16_t>(std::atoi(env_port));
+        }
+    }
+    if (host_ == "localhost") {
+        host_ = "127.0.0.1";
+    }
+
+    if (!init_socket()) {
+        throw std::runtime_error("Failed to initialize UDP socket");
+    }
+}
+
+void SimpleReportClient::set_server(const std::string& host) {
+    set_server(host, port_);
+}
+
 Result<ReportResult> SimpleReportClient::send_report_data() {
     if (!area_code_.has_value()) {
         return make_error_code(WipErrc::invalid_packet);


### PR DESCRIPTION
## Summary
- allow choosing report server via proxy flag or ServerConfig
- support changing SimpleReportClient server with new set_server method
- configure Client::initialize_report_client to resolve weather or report server dynamically

## Testing
- `cmake -S cpp -B cpp/build` *(fails: Cannot find source file: src/packet/debug/debug_logger.cpp)*
- `g++ -std=c++20 -I cpp/include -c cpp/src/client/client.cpp` *(fails: wiplib/packet/debug/debug_logger.hpp: No such file or directory)*
- `(cd cpp && bash simple_build.sh)` *(fails: undefined reference to wiplib::utils::load_dotenv and std::span errors)*


------
https://chatgpt.com/codex/tasks/task_e_68a4131239688322b57ba9db4b18cc73