### PR TITLE
feat: add debug option to query client

### DIFF
--- a/cpp/include/wiplib/client/query_client.hpp
+++ b/cpp/include/wiplib/client/query_client.hpp
@@ -14,8 +14,9 @@ namespace wiplib::client {
 
 class QueryClient {
 public:
-  QueryClient(std::string host = "127.0.0.1", uint16_t port = 4111)
-    : host_(std::move(host)), port_(port) {}
+  QueryClient(std::string host = "127.0.0.1", uint16_t port = 4111,
+              bool debug = false)
+    : host_(std::move(host)), port_(port), debug_(debug) {}
 
   wiplib::Result<WeatherResult> get_weather_data(std::string_view area_code,
                                                  const QueryOptions& opt) noexcept;
@@ -27,6 +28,7 @@ public:
 private:
   std::string host_;
   uint16_t port_;
+  bool debug_ = false;
   AuthConfig auth_cfg_{};
 };
 

--- a/cpp/src/client/query_client.cpp
+++ b/cpp/src/client/query_client.cpp
@@ -49,15 +49,23 @@ wiplib::Result<WeatherResult> QueryClient::get_weather_data(std::string_view are
       p.header.timestamp = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::seconds>(
           std::chrono::system_clock::now().time_since_epoch()).count());
       // Debug output
-      std::cerr << "DEBUG: Adding auth hash with passphrase: " << *auth_cfg_.query << std::endl;
+      if (debug_) {
+        std::cerr << "DEBUG: Adding auth hash with passphrase: " << *auth_cfg_.query << std::endl;
+      }
       bool auth_result = wiplib::utils::WIPAuth::attach_auth_hash(p, *auth_cfg_.query);
-      std::cerr << "DEBUG: Auth attach result: " << (auth_result ? "success" : "failed") << std::endl;
-      std::cerr << "DEBUG: Extensions count: " << p.extensions.size() << std::endl;
+      if (debug_) {
+        std::cerr << "DEBUG: Auth attach result: " << (auth_result ? "success" : "failed") << std::endl;
+        std::cerr << "DEBUG: Extensions count: " << p.extensions.size() << std::endl;
+      }
     } else {
-      std::cerr << "DEBUG: Auth enabled but no query passphrase set" << std::endl;
+      if (debug_) {
+        std::cerr << "DEBUG: Auth enabled but no query passphrase set" << std::endl;
+      }
     }
   } else {
-    std::cerr << "DEBUG: Auth not enabled" << std::endl;
+    if (debug_) {
+      std::cerr << "DEBUG: Auth not enabled" << std::endl;
+    }
   }
 
   auto enc = encode_packet(p);

--- a/cpp/src/client/wip_client.cpp
+++ b/cpp/src/client/wip_client.cpp
@@ -122,7 +122,7 @@ Result<std::string> WipClient::resolve_area_code_direct(double lat, double lon, 
 }
 
 Result<WeatherData> WipClient::query_weather_direct(std::string_view area_code, const WeatherOptions& opt) noexcept {
-  QueryClient qc(query_host_, query_port_);
+  QueryClient qc(query_host_, query_port_, debug_);
   qc.set_auth_config(auth_cfg_);
   QueryOptions qo{}; qo.weather=opt.weather; qo.temperature=opt.temperature; qo.precipitation_prob=opt.precipitation_prob; qo.alerts=opt.alert; qo.disaster=opt.disaster; qo.day=opt.day;
   auto r = qc.get_weather_data(area_code, qo);


### PR DESCRIPTION
## Summary
- allow QueryClient to accept a debug flag
- pass debug flag from WipClient to QueryClient
- guard debug log output in get_weather_data

## Testing
- `bash simple_build.sh` (fails: std::span has not been declared)
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4131e2c4c8322af9a8780f45d0ceb