### PR TITLE
feat: load client endpoints from env

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -136,3 +136,8 @@ c.set_auth_config(ac);
 - C++ クライアントは `AuthConfig::from_env()` 呼び出し時に、カレントディレクトリから親ディレクトリ方向に最大3階層まで `.env` を自動読み込みします（既存の環境変数は上書きしません）。
 - 特定パスを指定したい場合は `WIP_DOTENV_PATH` を設定してください（例: `WIP_DOTENV_PATH=/path/to/.env`）。
 - これにより `.env` に `*_REQUEST_AUTH_ENABLED` や `*_SERVER_PASSPHRASE` を記述するだけで、C++ 側でも認証が有効化されます。
+- `WeatherClient::from_env()` や `LocationClient::from_env()` などを利用すると、以下の環境変数から接続先ホスト・ポートを取得できます。
+  - `WEATHER_SERVER_HOST` / `WEATHER_SERVER_PORT`
+  - `LOCATION_RESOLVER_HOST` / `LOCATION_RESOLVER_PORT`
+  - `QUERY_GENERATOR_HOST` / `QUERY_GENERATOR_PORT`
+  例: `auto cli = wiplib::client::WeatherClient::from_env();`

--- a/cpp/include/wiplib/client/location_client.hpp
+++ b/cpp/include/wiplib/client/location_client.hpp
@@ -52,8 +52,13 @@ struct CoordinateResult {
 
 class LocationClient {
 public:
-  LocationClient(std::string host = "127.0.0.1", uint16_t port = 4109)
+  LocationClient(std::string host = default_host(),
+                 uint16_t port = default_port())
     : host_(std::move(host)), port_(port) {}
+
+  static LocationClient from_env();
+  static std::string default_host();
+  static uint16_t default_port();
 
   // 既存メソッド
   wiplib::Result<std::string> get_area_code_simple(double latitude, double longitude) noexcept;

--- a/cpp/include/wiplib/client/query_client.hpp
+++ b/cpp/include/wiplib/client/query_client.hpp
@@ -14,9 +14,13 @@ namespace wiplib::client {
 
 class QueryClient {
 public:
-  QueryClient(std::string host = "127.0.0.1", uint16_t port = 4111,
+  QueryClient(std::string host = default_host(), uint16_t port = default_port(),
               bool debug = false)
     : host_(std::move(host)), port_(port), debug_(debug) {}
+
+  static QueryClient from_env(bool debug = false);
+  static std::string default_host();
+  static uint16_t default_port();
 
   wiplib::Result<WeatherResult> get_weather_data(std::string_view area_code,
                                                  const QueryOptions& opt) noexcept;

--- a/cpp/include/wiplib/client/weather_client.hpp
+++ b/cpp/include/wiplib/client/weather_client.hpp
@@ -32,8 +32,14 @@ struct WeatherResult {
 
 class WeatherClient {
 public:
-  WeatherClient(std::string host, uint16_t port) : host_(std::move(host)), port_(port) {}
+  WeatherClient(std::string host = default_host(),
+                uint16_t port = default_port())
+      : host_(std::move(host)), port_(port) {}
   ~WeatherClient() = default;
+
+  static WeatherClient from_env();
+  static std::string default_host();
+  static uint16_t default_port();
 
   // Python版に合わせた命名
   wiplib::Result<WeatherResult> get_weather_by_coordinates(double lat, double lon, const QueryOptions& opt) noexcept;

--- a/cpp/include/wiplib/client/wip_client.hpp
+++ b/cpp/include/wiplib/client/wip_client.hpp
@@ -15,8 +15,8 @@
 namespace wiplib::client {
 
 struct ServerConfig {
-  std::string host = "127.0.0.1";
-  uint16_t port = 4110; // Weather Server (proxy)
+  std::string host = WeatherClient::default_host();
+  uint16_t port = WeatherClient::default_port(); // Weather Server (proxy)
 };
 
 struct ClientState {
@@ -46,6 +46,7 @@ struct WeatherData {
 class WipClient {
 public:
   explicit WipClient(ServerConfig cfg = {}, bool debug = false);
+  static WipClient from_env(bool debug = false);
   ~WipClient();
 
   void set_coordinates(double latitude, double longitude);

--- a/cpp/src/client/location_client.cpp
+++ b/cpp/src/client/location_client.cpp
@@ -6,6 +6,7 @@
 #include "wiplib/packet/extended_field.hpp"
 #include "wiplib/packet/request.hpp"
 #include "wiplib/packet/response.hpp"
+#include "wiplib/utils/dotenv.hpp"
 #include <vector>
 #include <string>
 #include <cstdio>
@@ -17,6 +18,7 @@
 #include <optional>
 #include <sstream>
 #include <iomanip>
+#include <cstdlib>
 
 #if defined(_WIN32)
 #  include <winsock2.h>
@@ -34,6 +36,22 @@ using socklen_t = int;
 #endif
 
 namespace wiplib::client {
+
+LocationClient LocationClient::from_env() {
+  return LocationClient(default_host(), default_port());
+}
+
+std::string LocationClient::default_host() {
+  (void)wiplib::utils::load_dotenv(".env", false, 3);
+  if (const char* h = std::getenv("LOCATION_RESOLVER_HOST")) return h;
+  return "127.0.0.1";
+}
+
+uint16_t LocationClient::default_port() {
+  (void)wiplib::utils::load_dotenv(".env", false, 3);
+  if (const char* p = std::getenv("LOCATION_RESOLVER_PORT")) return static_cast<uint16_t>(std::stoi(p));
+  return 4109;
+}
 
 using namespace wiplib::proto;
 

--- a/cpp/src/client/query_client.cpp
+++ b/cpp/src/client/query_client.cpp
@@ -3,10 +3,12 @@
 #include "wiplib/packet/codec.hpp"
 #include "wiplib/utils/auth.hpp"
 #include "wiplib/packet/extended_field.hpp"
+#include "wiplib/utils/dotenv.hpp"
 #include <variant>
 #include <chrono>
 #include <random>
 #include <iostream>
+#include <cstdlib>
 
 #if defined(_WIN32)
 #  include <winsock2.h>
@@ -26,6 +28,22 @@ using socklen_t = int;
 namespace wiplib::client {
 
 using namespace wiplib::proto;
+
+QueryClient QueryClient::from_env(bool debug) {
+  return QueryClient(default_host(), default_port(), debug);
+}
+
+std::string QueryClient::default_host() {
+  (void)wiplib::utils::load_dotenv(".env", false, 3);
+  if (const char* h = std::getenv("QUERY_GENERATOR_HOST")) return h;
+  return "127.0.0.1";
+}
+
+uint16_t QueryClient::default_port() {
+  (void)wiplib::utils::load_dotenv(".env", false, 3);
+  if (const char* p = std::getenv("QUERY_GENERATOR_PORT")) return static_cast<uint16_t>(std::stoi(p));
+  return 4111;
+}
 
 wiplib::Result<WeatherResult> QueryClient::get_weather_data(std::string_view area_code,
                                                             const QueryOptions& opt) noexcept {

--- a/cpp/src/client/weather_client.cpp
+++ b/cpp/src/client/weather_client.cpp
@@ -3,11 +3,13 @@
 #include "wiplib/packet/codec.hpp"
 #include "wiplib/utils/auth.hpp"
 #include "wiplib/packet/extended_field.hpp"
+#include "wiplib/utils/dotenv.hpp"
 #include <variant>
 #include <chrono>
 #include <random>
 #include <cstring>
 #include <cstdio>
+#include <cstdlib>
 
 #if defined(_WIN32)
 #  include <winsock2.h>
@@ -23,6 +25,22 @@ using socklen_t = int;
 #endif
 
 namespace wiplib::client {
+
+WeatherClient WeatherClient::from_env() {
+  return WeatherClient(default_host(), default_port());
+}
+
+std::string WeatherClient::default_host() {
+  (void)wiplib::utils::load_dotenv(".env", false, 3);
+  if (const char* h = std::getenv("WEATHER_SERVER_HOST")) return h;
+  return "127.0.0.1";
+}
+
+uint16_t WeatherClient::default_port() {
+  (void)wiplib::utils::load_dotenv(".env", false, 3);
+  if (const char* p = std::getenv("WEATHER_SERVER_PORT")) return static_cast<uint16_t>(std::stoi(p));
+  return 4110;
+}
 
 wiplib::Result<WeatherResult> WeatherClient::get_weather_by_coordinates(double lat, double lon, const QueryOptions& opt) noexcept {
   using namespace wiplib::proto;

--- a/cpp/src/client/wip_client.cpp
+++ b/cpp/src/client/wip_client.cpp
@@ -4,10 +4,12 @@
 #include "wiplib/client/location_client.hpp"
 #include "wiplib/client/query_client.hpp"
 #include "wiplib/client/auth_config.hpp"
+#include "wiplib/utils/dotenv.hpp"
 #include <chrono>
 #include <cstring>
 #include <random>
 #include <cstdio>
+#include <cstdlib>
 
 #if defined(_WIN32)
 #  include <winsock2.h>
@@ -29,6 +31,19 @@ using namespace wiplib::proto;
 static uint64_t now_sec() {
   return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::seconds>(
       std::chrono::system_clock::now().time_since_epoch()).count());
+}
+
+WipClient WipClient::from_env(bool debug) {
+  (void)wiplib::utils::load_dotenv(".env", false, 3);
+  ServerConfig cfg{};
+  if (const char* h = std::getenv("WEATHER_SERVER_HOST")) cfg.host = h;
+  if (const char* p = std::getenv("WEATHER_SERVER_PORT")) cfg.port = static_cast<uint16_t>(std::stoi(p));
+  WipClient client(cfg, debug);
+  if (const char* lh = std::getenv("LOCATION_RESOLVER_HOST")) client.location_host_ = lh;
+  if (const char* lp = std::getenv("LOCATION_RESOLVER_PORT")) client.location_port_ = static_cast<uint16_t>(std::stoi(lp));
+  if (const char* qh = std::getenv("QUERY_GENERATOR_HOST")) client.query_host_ = qh;
+  if (const char* qp = std::getenv("QUERY_GENERATOR_PORT")) client.query_port_ = static_cast<uint16_t>(std::stoi(qp));
+  return client;
 }
 
 WipClient::WipClient(ServerConfig cfg, bool debug)


### PR DESCRIPTION
## Summary
- allow C++ clients to read server host/port from environment variables
- document host/port environment configuration in README

## Testing
- `pytest -q`
- `g++ -std=c++20 -I cpp/include -c cpp/src/client/weather_client.cpp -o /tmp/weather.o`
- `g++ -std=c++20 -fpermissive -I cpp/include -c cpp/src/client/location_client.cpp -o /tmp/location.o`
- `g++ -std=c++20 -I cpp/include -c cpp/src/client/query_client.cpp -o /tmp/query.o`
- `g++ -std=c++20 -I cpp/include -c cpp/src/client/wip_client.cpp -o /tmp/wip.o`


------
https://chatgpt.com/codex/tasks/task_e_68a47e6497688322b001a90cea560440