### PR TITLE
Remove unused WIP_CLIENT_AUTH_ENABLED references

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -94,7 +94,6 @@ Python版との対応
 認証設定
 - 概要: Pythonクライアントの認証挙動を再現。HMAC-SHA256 を拡張フィールド(ID=4)へ hex64 で付与（`flags.extended=true`）。
 - 環境変数:
-  - `WIP_CLIENT_AUTH_ENABLED=1`（認証付与を有効化）
   - `WIP_CLIENT_VERIFY_RESPONSE_AUTH=1`（受信パケットの検証を有効化）
   - `WEATHER_SERVER_PASSPHRASE`（WeatherServer 宛の共有パスフレーズ）
   - `LOCATION_SERVER_PASSPHRASE`（LocationResolver 宛の共有パスフレーズ）

--- a/cpp/docs/AUTH_SPEC.md
+++ b/cpp/docs/AUTH_SPEC.md
@@ -88,7 +88,6 @@ Python 実装:
 3) Report サーバーを叩く機能を将来追加する場合は `REPORT_SERVER_PASSPHRASE` を使用。
 
 環境変数（推奨デフォルト）:
-- `WIP_CLIENT_AUTH_ENABLED` = `true|false`（デフォルト: `false`）
 - `WEATHER_SERVER_PASSPHRASE`, `LOCATION_SERVER_PASSPHRASE`, `QUERY_SERVER_PASSPHRASE`, `REPORT_SERVER_PASSPHRASE`
   - API での上書きを優先し、未設定時は空扱い（= 認証付与しない）。
 
@@ -109,7 +108,7 @@ Python 実装:
   - パケットの `header.flags.extended = true` を忘れずに。
 
 - クライアント群
-  - `WeatherClient` 送信直前に、`WIP_CLIENT_AUTH_ENABLED` と `WEATHER_SERVER_PASSPHRASE` を確認し、必要なら `auth_hash` を付与。
+  - `WeatherClient` 送信直前に `WEATHER_SERVER_PASSPHRASE` を確認し、必要なら `auth_hash` を付与。
   - `LocationClient` / `QueryClient`（直叩きのとき）も同様に、宛先別パスフレーズで付与。
   - 高水準 `WipClient` は内部で利用する `LocationClient`/`QueryClient` に伝播できるよう設定 API を用意。
 

--- a/cpp/docs/AUTH_TASKS.md
+++ b/cpp/docs/AUTH_TASKS.md
@@ -14,7 +14,7 @@
 
 2. 認証設定構造体の追加
    - 追加: `struct AuthConfig { bool enabled; std::optional<std::string> weather, location, query, report; bool verify_response=false; };`
-   - 環境変数読取（任意）: `WIP_CLIENT_AUTH_ENABLED`, `WEATHER_SERVER_PASSPHRASE`, `LOCATION_SERVER_PASSPHRASE`, `QUERY_SERVER_PASSPHRASE`, `REPORT_SERVER_PASSPHRASE`
+   - 環境変数読取（任意）: `WEATHER_SERVER_PASSPHRASE`, `LOCATION_SERVER_PASSPHRASE`, `QUERY_SERVER_PASSPHRASE`, `REPORT_SERVER_PASSPHRASE`
    - 変更ファイル: `cpp/include/wiplib/client/*`（公開 API）、`cpp/src/client/*`
 
 受け入れ条件

--- a/cpp/include/wiplib/client/auth_config.hpp
+++ b/cpp/include/wiplib/client/auth_config.hpp
@@ -6,7 +6,7 @@
 namespace wiplib::client {
 
 struct AuthConfig {
-    bool enabled = false; // global switch via WIP_CLIENT_AUTH_ENABLED
+    bool enabled = false; // 全体の有効化フラグ（いずれかの認証設定が有効なら true）
     bool weather_request_auth_enabled = false;
     bool location_resolver_request_auth_enabled = false;
     bool query_generator_request_auth_enabled = false;


### PR DESCRIPTION
## Summary
- remove outdated WIP_CLIENT_AUTH_ENABLED mention from docs
- clarify AuthConfig enabled flag comment

## Testing
- `cmake -S cpp -B cpp/build -DCMAKE_BUILD_TYPE=Release -DWIPLIB_BUILD_TESTS=ON` *(failed: unable to clone googletest)*
- `apt-get update` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a47f210640832285c11ad59483d54c