### PR TITLE
feat: persist location cache to disk

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -121,6 +121,7 @@ if(WIPLIB_BUILD_TESTS)
     tests/unit/test_config_loader.cpp
     tests/unit/test_log_config.cpp
     tests/unit/test_network.cpp
+    tests/unit/test_location_cache_persistence.cpp
     tests/integration/test_weather_client.cpp
     tests/integration/test_async_weather_client.cpp
     tests/integration/test_client.cpp

--- a/cpp/include/wiplib/client/location_client.hpp
+++ b/cpp/include/wiplib/client/location_client.hpp
@@ -56,7 +56,8 @@ class LocationClient {
 public:
   LocationClient(std::string host = "127.0.0.1", uint16_t port = 4109)
     : host_(std::move(host)), port_(port) {
-    cache_file_path_ = std::filesystem::temp_directory_path() / "wip_location_cache.json";
+    // Python互換のキャッシュファイルパス
+    cache_file_path_ = std::filesystem::current_path() / "coordinate_cache.json";
     load_cache_from_disk();
   }
 
@@ -174,6 +175,15 @@ public:
   void set_server(std::string host, uint16_t port) { 
       host_ = std::move(host); 
       port_ = port; 
+  }
+  
+  /**
+   * @brief キャッシュファイルパスを設定（Python互換）
+   * @param cache_file_path キャッシュファイルパス
+   */
+  void set_cache_file_path(const std::filesystem::path& cache_file_path) {
+    cache_file_path_ = cache_file_path;
+    load_cache_from_disk();
   }
 
   void set_auth_config(const AuthConfig& cfg) { auth_cfg_ = cfg; }

--- a/cpp/include/wiplib/client/location_client.hpp
+++ b/cpp/include/wiplib/client/location_client.hpp
@@ -8,6 +8,8 @@
 #include <chrono>
 #include <optional>
 #include <unordered_map>
+#include <mutex>
+#include <filesystem>
 
 #include "wiplib/expected.hpp"
 #include "wiplib/error.hpp"
@@ -53,7 +55,10 @@ struct CoordinateResult {
 class LocationClient {
 public:
   LocationClient(std::string host = "127.0.0.1", uint16_t port = 4109)
-    : host_(std::move(host)), port_(port) {}
+    : host_(std::move(host)), port_(port) {
+    cache_file_path_ = std::filesystem::temp_directory_path() / "wip_location_cache.json";
+    load_cache_from_disk();
+  }
 
   // 既存メソッド
   wiplib::Result<std::string> get_area_code_simple(double latitude, double longitude) noexcept;
@@ -186,6 +191,7 @@ private:
   std::chrono::seconds cache_ttl_{300};
   mutable std::unordered_map<std::string, std::pair<CoordinateResult, std::chrono::steady_clock::time_point>> cache_;
   mutable std::mutex cache_mutex_;
+  std::filesystem::path cache_file_path_;
   
   // 統計
   mutable std::mutex stats_mutex_;
@@ -203,12 +209,17 @@ private:
   std::optional<CoordinateResult> get_cached_result(const std::string& cache_key) const;
   
   void cache_result(const std::string& cache_key, const CoordinateResult& result) const;
-  
+
+  void load_cache_from_disk();
+  void save_cache_to_disk() const;
+
   void update_statistics(const std::string& key, uint64_t increment = 1) const;
   
   double calculate_accuracy_from_precision(PrecisionLevel precision_level) const;
   
   bool is_coordinate_in_bounds(const packet::Coordinate& coordinate, const GeographicBounds& bounds) const;
+
+  friend class LocationClientCacheTestHelper;
 };
 
 /**

--- a/cpp/tests/unit/test_location_cache_persistence.cpp
+++ b/cpp/tests/unit/test_location_cache_persistence.cpp
@@ -17,10 +17,11 @@ public:
 
 TEST(LocationClientCachePersistence, ReloadsFromDisk) {
     namespace fs = std::filesystem;
-    auto path = fs::temp_directory_path() / "wip_location_cache.json";
+    auto path = fs::temp_directory_path() / "test_location_cache.json";
     if (fs::exists(path)) fs::remove(path);
 
     LocationClientCacheTestHelper c1;
+    c1.set_cache_file_path(path);
     c1.set_cache_enabled(true, std::chrono::seconds{60});
     packet::Coordinate coord{35.0, 139.0};
     CoordinateResult res{};
@@ -31,6 +32,7 @@ TEST(LocationClientCachePersistence, ReloadsFromDisk) {
     c1.cache_public(c1.key_public(coord, PrecisionLevel::Medium), res);
 
     LocationClient c2;
+    c2.set_cache_file_path(path);
     c2.set_cache_enabled(true, std::chrono::seconds{60});
     auto fut = c2.get_area_code_detailed_async(coord, PrecisionLevel::Medium);
     auto result = fut.get();
@@ -38,4 +40,57 @@ TEST(LocationClientCachePersistence, ReloadsFromDisk) {
     EXPECT_EQ(result->area_code, "654321");
 
     if (fs::exists(path)) fs::remove(path);
+}
+
+TEST(LocationClientCachePersistence, PythonCompatibleFormat) {
+    namespace fs = std::filesystem;
+    auto path = fs::temp_directory_path() / "test_python_cache.json";
+    if (fs::exists(path)) fs::remove(path);
+
+    // Python形式のキャッシュファイルを作成
+    std::ofstream ofs(path);
+    ofs << R"({
+  "coord:35.6895,139.6917": {
+    "area_code": "130001",
+    "timestamp": 1692345678.123456
+  },
+  "coord:34.0522,-118.2437": {
+    "area_code": "060001", 
+    "timestamp": 1692345679.987654
+  }
+})";
+    ofs.close();
+
+    // C++クライアントでPython形式を読み込み
+    LocationClient client;
+    client.set_cache_file_path(path);
+    client.set_cache_enabled(true, std::chrono::seconds{3600});
+
+    packet::Coordinate coord1{35.6895, 139.6917};
+    auto fut1 = client.get_area_code_detailed_async(coord1, PrecisionLevel::Medium);
+    auto result1 = fut1.get();
+    ASSERT_TRUE(result1.has_value());
+    EXPECT_EQ(result1->area_code, "130001");
+
+    packet::Coordinate coord2{34.0522, -118.2437};
+    auto fut2 = client.get_area_code_detailed_async(coord2, PrecisionLevel::Medium);
+    auto result2 = fut2.get();
+    ASSERT_TRUE(result2.has_value());
+    EXPECT_EQ(result2->area_code, "060001");
+
+    if (fs::exists(path)) fs::remove(path);
+}
+
+TEST(LocationClientCachePersistence, CacheKeyCompatibility) {
+    LocationClientCacheTestHelper helper;
+    
+    // Pythonと同じキー形式を確認
+    packet::Coordinate coord{35.6895, 139.6917};
+    std::string key = helper.key_public(coord, PrecisionLevel::Medium);
+    EXPECT_EQ(key, "coord:35.6895,139.6917");
+    
+    // 精度4桁の丸めを確認
+    packet::Coordinate coord_precise{35.68954321, 139.69176789};
+    std::string key_precise = helper.key_public(coord_precise, PrecisionLevel::Medium);
+    EXPECT_EQ(key_precise, "coord:35.6895,139.6918");
 }

--- a/cpp/tests/unit/test_location_cache_persistence.cpp
+++ b/cpp/tests/unit/test_location_cache_persistence.cpp
@@ -1,0 +1,41 @@
+#include <gtest/gtest.h>
+#include "wiplib/client/location_client.hpp"
+#include <filesystem>
+
+using namespace wiplib::client;
+
+class LocationClientCacheTestHelper : public LocationClient {
+public:
+    using LocationClient::LocationClient;
+    void cache_public(const std::string& key, const CoordinateResult& res) {
+        cache_result(key, res);
+    }
+    std::string key_public(const packet::Coordinate& c, PrecisionLevel p) const {
+        return generate_cache_key(c, p);
+    }
+};
+
+TEST(LocationClientCachePersistence, ReloadsFromDisk) {
+    namespace fs = std::filesystem;
+    auto path = fs::temp_directory_path() / "wip_location_cache.json";
+    if (fs::exists(path)) fs::remove(path);
+
+    LocationClientCacheTestHelper c1;
+    c1.set_cache_enabled(true, std::chrono::seconds{60});
+    packet::Coordinate coord{35.0, 139.0};
+    CoordinateResult res{};
+    res.area_code = "654321";
+    res.original_coordinate = coord;
+    res.normalized_coordinate = coord;
+    res.precision_level = PrecisionLevel::Medium;
+    c1.cache_public(c1.key_public(coord, PrecisionLevel::Medium), res);
+
+    LocationClient c2;
+    c2.set_cache_enabled(true, std::chrono::seconds{60});
+    auto fut = c2.get_area_code_detailed_async(coord, PrecisionLevel::Medium);
+    auto result = fut.get();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->area_code, "654321");
+
+    if (fs::exists(path)) fs::remove(path);
+}


### PR DESCRIPTION
## Summary
- cache LocationClient results to JSON on disk and reload on startup
- remove expired entries based on TTL
- test that cache persists across client instances

## Testing
- `cd cpp && cmake -B build -DWIPLIB_BUILD_TESTS=ON` *(fails: Failed to clone repository: 'https://github.com/google/googletest.git')*

------
https://chatgpt.com/codex/tasks/task_e_68a47f33d5888322bbac8f7bb5310012