### PR TITLE
CMakeによるビルド設定を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 !.env.example
 *.egg-info/
 dist/
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.15)
+project(WIP LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(wip_app src/main.cpp)
+
+find_package(Threads REQUIRED)
+target_link_libraries(wip_app PRIVATE Threads::Threads)
+
+set_target_properties(wip_app PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello from CMake" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- CMakeLists.txtを作成し、Threads依存を含む`wip_app`ターゲットを追加
- `build/`ディレクトリにビルド成果物を分離

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68a519701f3083228073108126238a8d