### PR TITLE
Windows/Linux 向けPOSIXラッパーの追加

### DIFF
--- a/src/PosixWrapper.cpp
+++ b/src/PosixWrapper.cpp
@@ -1,0 +1,39 @@
+#include "PosixWrapper.h"
+
+namespace PosixWrapper {
+
+socket_t create_socket() {
+#ifdef _WIN32
+    WSADATA wsa;
+    WSAStartup(MAKEWORD(2,2), &wsa);
+    return socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+#else
+    return socket(AF_INET, SOCK_STREAM, 0);
+#endif
+}
+
+int close_socket(socket_t sock) {
+#ifdef _WIN32
+    return closesocket(sock);
+#else
+    return close(sock);
+#endif
+}
+
+int open_file(const char* path, int flags) {
+#ifdef _WIN32
+    return _open(path, flags);
+#else
+    return open(path, flags);
+#endif
+}
+
+int close_file(int fd) {
+#ifdef _WIN32
+    return _close(fd);
+#else
+    return close(fd);
+#endif
+}
+
+} // namespace PosixWrapper

--- a/src/PosixWrapper.h
+++ b/src/PosixWrapper.h
@@ -1,0 +1,28 @@
+#ifndef POSIXWRAPPER_H
+#define POSIXWRAPPER_H
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
+#include <io.h>
+#include <fcntl.h>
+using socket_t = SOCKET;
+#else
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <fcntl.h>
+using socket_t = int;
+#endif
+
+namespace PosixWrapper {
+    socket_t create_socket();
+    int close_socket(socket_t sock);
+    int open_file(const char* path, int flags);
+    int close_file(int fd);
+}
+
+#endif // POSIXWRAPPER_H


### PR DESCRIPTION
## Summary
- WindowsとLinuxの実装を切り替えるPosixWrapperを作成

## Testing
- `g++ -std=c++17 -c src/PosixWrapper.cpp -o /tmp/PosixWrapper.o`
- `pytest` (ModuleNotFoundError: dotenv, fastapi)


------
https://chatgpt.com/codex/tasks/task_e_68a5197d73b883228bc28028cef8cb36