### PR TITLE
ファイルシステムと環境変数のユーティリティ追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ __pycache__
 *.pem
 /.vscode/
 /Rust/target/
-/cpp/
 /python/logs/json
 /logs/reports
 !.env.example

--- a/cpp/utils/platform_utils.h
+++ b/cpp/utils/platform_utils.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <cstdlib>
+#include <string>
+#include <optional>
+#include <filesystem>
+#include <codecvt>
+#include <locale>
+
+namespace wip {
+
+inline std::filesystem::path join_paths(std::initializer_list<std::filesystem::path> parts) {
+    std::filesystem::path result;
+    for (const auto& p : parts) {
+        result /= p;
+    }
+    return result;
+}
+
+enum class EnvKey {
+    HomeDir,
+    ConfigDir
+};
+
+inline std::optional<std::string> get_env(EnvKey key) {
+    const char* name = nullptr;
+#ifdef _WIN32
+    switch (key) {
+        case EnvKey::HomeDir: name = "USERPROFILE"; break;
+        case EnvKey::ConfigDir: name = "APPDATA"; break;
+    }
+#else
+    switch (key) {
+        case EnvKey::HomeDir: name = "HOME"; break;
+        case EnvKey::ConfigDir: name = "XDG_CONFIG_HOME"; break;
+    }
+#endif
+    if (!name) {
+        return std::nullopt;
+    }
+    if (const char* value = std::getenv(name)) {
+        return std::string(value);
+    }
+    return std::nullopt;
+}
+
+inline std::u16string utf8_to_utf16(const std::string& input) {
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> conv;
+    return conv.from_bytes(input);
+}
+
+inline std::string utf16_to_utf8(const std::u16string& input) {
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> conv;
+    return conv.to_bytes(input);
+}
+
+} // namespace wip
+


### PR DESCRIPTION
## Summary
- add platform_utils with filesystem path joining, environment variable wrapper, UTF8/UTF16 conversion helpers
- allow cpp directory to be tracked

## Testing
- `g++ -std=c++17 cpp/test_compile.cpp -c`
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv'; ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a5199c66388322bc0e295df42d0c81