### PR TITLE
Add CI workflow for Linux and Windows builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure
+        run: cmake -S . -B build
+      - name: Build
+        run: cmake --build build
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure
+        run: cmake -S . -B build
+      - name: Build
+        run: cmake --build build
+      - name: Test
+        run: ctest --test-dir build --output-on-failure


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and test with CMake on both Linux and Windows

## Testing
- `pip install python-dotenv fastapi` (fails: Could not find a version that satisfies the requirement python-dotenv)
- `pytest` (fails: ModuleNotFoundError: No module named 'dotenv')

------
https://chatgpt.com/codex/tasks/task_e_68a519a7f4cc8322892084ffb974535b