### PR TITLE
Add root CMake build with thread demo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(wiproot LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+find_package(Threads REQUIRED)
+
+add_executable(thread_demo main.cpp)
+target_link_libraries(thread_demo PRIVATE Threads::Threads)

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+#include <thread>
+
+int main() {
+    std::thread t([](){ std::cout << "Hello from thread!" << std::endl; });
+    t.join();
+    std::cout << "Hello from main!" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- set up a top-level CMake project that builds to `build/`
- include simple `std::thread` demo executable

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68a583d3b1e48322bf607769543e7a64