### PR TITLE
PosixWrapperによるWindows/Linux実装の切り替え

### DIFF
--- a/cpp/include/wiplib/utils/posix_wrapper.hpp
+++ b/cpp/include/wiplib/utils/posix_wrapper.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <cstdlib>
+#include <string>
+
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#include <winsock2.h>
+#else
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+namespace wiplib::utils {
+
+class PosixWrapper {
+public:
+  static int openFile(const char *path, int flags, int mode = 0644);
+  static int closeFile(int fd);
+  static ssize_t readFile(int fd, void *buf, size_t count);
+  static ssize_t writeFile(int fd, const void *buf, size_t count);
+  static int createSocket(int domain, int type, int protocol);
+  static int closeSocket(int sock);
+  static bool setEnv(const std::string &key, const std::string &value,
+                     bool overwrite);
+};
+
+#ifdef _WIN32
+inline int PosixWrapper::openFile(const char *path, int flags, int mode) {
+  return _open(path, flags, mode);
+}
+inline int PosixWrapper::closeFile(int fd) { return _close(fd); }
+inline ssize_t PosixWrapper::readFile(int fd, void *buf, size_t count) {
+  return _read(fd, buf, static_cast<unsigned int>(count));
+}
+inline ssize_t PosixWrapper::writeFile(int fd, const void *buf, size_t count) {
+  return _write(fd, buf, static_cast<unsigned int>(count));
+}
+inline int PosixWrapper::createSocket(int domain, int type, int protocol) {
+  return static_cast<int>(::socket(domain, type, protocol));
+}
+inline int PosixWrapper::closeSocket(int sock) { return ::closesocket(sock); }
+inline bool PosixWrapper::setEnv(const std::string &key,
+                                 const std::string &value, bool overwrite) {
+  if (!overwrite) {
+    const char *existing = std::getenv(key.c_str());
+    if (existing)
+      return true;
+  }
+  return _putenv_s(key.c_str(), value.c_str()) == 0;
+}
+#else
+inline int PosixWrapper::openFile(const char *path, int flags, int mode) {
+  return ::open(path, flags, mode);
+}
+inline int PosixWrapper::closeFile(int fd) { return ::close(fd); }
+inline ssize_t PosixWrapper::readFile(int fd, void *buf, size_t count) {
+  return ::read(fd, buf, count);
+}
+inline ssize_t PosixWrapper::writeFile(int fd, const void *buf, size_t count) {
+  return ::write(fd, buf, count);
+}
+inline int PosixWrapper::createSocket(int domain, int type, int protocol) {
+  return ::socket(domain, type, protocol);
+}
+inline int PosixWrapper::closeSocket(int sock) { return ::close(sock); }
+inline bool PosixWrapper::setEnv(const std::string &key,
+                                 const std::string &value, bool overwrite) {
+  return ::setenv(key.c_str(), value.c_str(), overwrite ? 1 : 0) == 0;
+}
+#endif
+
+} // namespace wiplib::utils

--- a/cpp/src/utils/dotenv.cpp
+++ b/cpp/src/utils/dotenv.cpp
@@ -1,4 +1,5 @@
 #include "wiplib/utils/dotenv.hpp"
+#include "wiplib/utils/posix_wrapper.hpp"
 
 #include <algorithm>
 #include <cctype>
@@ -10,10 +11,10 @@
 #include <system_error>
 
 #if __has_include(<filesystem>)
-#  include <filesystem>
+#include <filesystem>
 namespace fs = std::filesystem;
 #else
-#  error "C++17 filesystem is required"
+#error "C++17 filesystem is required"
 #endif
 
 namespace wiplib::utils {
@@ -21,109 +22,112 @@ namespace wiplib::utils {
 namespace {
 
 static inline std::string trim(std::string s) {
-    auto not_space = [](unsigned char ch) { return !std::isspace(ch); };
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), not_space));
-    s.erase(std::find_if(s.rbegin(), s.rend(), not_space).base(), s.end());
-    return s;
+  auto not_space = [](unsigned char ch) { return !std::isspace(ch); };
+  s.erase(s.begin(), std::find_if(s.begin(), s.end(), not_space));
+  s.erase(std::find_if(s.rbegin(), s.rend(), not_space).base(), s.end());
+  return s;
 }
 
 static inline bool is_valid_key_char(char c) {
-    return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
+  return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
 }
 
 static inline std::string unquote(std::string v) {
-    if (v.size() >= 2) {
-        if ((v.front() == '"' && v.back() == '"') || (v.front() == '\'' && v.back() == '\'')) {
-            v = v.substr(1, v.size() - 2);
-        }
+  if (v.size() >= 2) {
+    if ((v.front() == '"' && v.back() == '"') ||
+        (v.front() == '\'' && v.back() == '\'')) {
+      v = v.substr(1, v.size() - 2);
     }
-    return v;
+  }
+  return v;
 }
 
-static inline bool set_env(const std::string& key, const std::string& val, bool overwrite) {
-#if defined(_WIN32)
-    if (!overwrite) {
-        const char* existing = std::getenv(key.c_str());
-        if (existing) return true;
-    }
-    return _putenv_s(key.c_str(), val.c_str()) == 0;
-#else
-    return ::setenv(key.c_str(), val.c_str(), overwrite ? 1 : 0) == 0;
-#endif
-}
-
-static std::optional<fs::path> resolve_env_path(const std::string& path, int max_parent_levels) {
-    // If absolute, use as-is
-    fs::path p(path);
-    if (p.is_absolute()) {
-        if (fs::exists(p) && fs::is_regular_file(p)) return p;
-        return std::nullopt;
-    }
-
-    // Allow override via WIP_DOTENV_PATH
-    if (const char* custom = std::getenv("WIP_DOTENV_PATH")) {
-        fs::path cp(custom);
-        if (fs::exists(cp) && fs::is_regular_file(cp)) return cp;
-    }
-
-    // Search current directory and up to N parents
-    fs::path cur = fs::current_path();
-    for (int i = 0; i <= max_parent_levels; ++i) {
-        fs::path candidate = cur / p;
-        if (fs::exists(candidate) && fs::is_regular_file(candidate)) {
-            return candidate;
-        }
-        if (!cur.has_parent_path()) break;
-        cur = cur.parent_path();
-    }
+static std::optional<fs::path> resolve_env_path(const std::string &path,
+                                                int max_parent_levels) {
+  // If absolute, use as-is
+  fs::path p(path);
+  if (p.is_absolute()) {
+    if (fs::exists(p) && fs::is_regular_file(p))
+      return p;
     return std::nullopt;
+  }
+
+  // Allow override via WIP_DOTENV_PATH
+  if (const char *custom = std::getenv("WIP_DOTENV_PATH")) {
+    fs::path cp(custom);
+    if (fs::exists(cp) && fs::is_regular_file(cp))
+      return cp;
+  }
+
+  // Search current directory and up to N parents
+  fs::path cur = fs::current_path();
+  for (int i = 0; i <= max_parent_levels; ++i) {
+    fs::path candidate = cur / p;
+    if (fs::exists(candidate) && fs::is_regular_file(candidate)) {
+      return candidate;
+    }
+    if (!cur.has_parent_path())
+      break;
+    cur = cur.parent_path();
+  }
+  return std::nullopt;
 }
 
 } // namespace
 
-bool load_dotenv(const std::string& path, bool overwrite, int max_parent_levels) {
-    static bool loaded_once = false;
-    // If already loaded and not overwriting, we can return quickly. Still try to find file for return value accuracy.
-    auto file_path = resolve_env_path(path, max_parent_levels);
-    if (!file_path) return false;
+bool load_dotenv(const std::string &path, bool overwrite,
+                 int max_parent_levels) {
+  static bool loaded_once = false;
+  // If already loaded and not overwriting, we can return quickly. Still try to
+  // find file for return value accuracy.
+  auto file_path = resolve_env_path(path, max_parent_levels);
+  if (!file_path)
+    return false;
 
-    // Avoid re-parsing unless overwrite requested
-    if (loaded_once && !overwrite) return true;
+  // Avoid re-parsing unless overwrite requested
+  if (loaded_once && !overwrite)
+    return true;
 
-    std::ifstream ifs(*file_path);
-    if (!ifs) return false;
+  std::ifstream ifs(*file_path);
+  if (!ifs)
+    return false;
 
-    std::string line;
-    while (std::getline(ifs, line)) {
-        std::string s = trim(line);
-        if (s.empty()) continue;
-        if (s[0] == '#') continue;
+  std::string line;
+  while (std::getline(ifs, line)) {
+    std::string s = trim(line);
+    if (s.empty())
+      continue;
+    if (s[0] == '#')
+      continue;
 
-        // Find '=' separator
-        auto eq = s.find('=');
-        if (eq == std::string::npos) continue;
-        std::string key = trim(s.substr(0, eq));
-        std::string val = trim(s.substr(eq + 1));
+    // Find '=' separator
+    auto eq = s.find('=');
+    if (eq == std::string::npos)
+      continue;
+    std::string key = trim(s.substr(0, eq));
+    std::string val = trim(s.substr(eq + 1));
 
-        // Validate key characters
-        if (key.empty() || !std::all_of(key.begin(), key.end(), is_valid_key_char)) continue;
+    // Validate key characters
+    if (key.empty() || !std::all_of(key.begin(), key.end(), is_valid_key_char))
+      continue;
 
-        // Handle optional export prefix
-        if (key.rfind("export ", 0) == 0) {
-            key = trim(key.substr(7));
-            if (key.empty() || !std::all_of(key.begin(), key.end(), is_valid_key_char)) continue;
-        }
-
-        // Allow quoted values
-        val = unquote(val);
-
-        // Do not override unless allowed
-        set_env(key, val, overwrite);
+    // Handle optional export prefix
+    if (key.rfind("export ", 0) == 0) {
+      key = trim(key.substr(7));
+      if (key.empty() ||
+          !std::all_of(key.begin(), key.end(), is_valid_key_char))
+        continue;
     }
 
-    loaded_once = true;
-    return true;
+    // Allow quoted values
+    val = unquote(val);
+
+    // Do not override unless allowed
+    PosixWrapper::setEnv(key, val, overwrite);
+  }
+
+  loaded_once = true;
+  return true;
 }
 
 } // namespace wiplib::utils
-


### PR DESCRIPTION
## Summary
- add `posix_wrapper.hpp` that abstracts file and socket operations via `#ifdef _WIN32`
- use `PosixWrapper::setEnv` inside dotenv utility

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a583dc77ec8322b067026c9dc454ba