### PR TITLE
Add Windows dependency guidance and CMake hints

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -59,6 +59,32 @@ target_include_directories(wiplib
 find_package(Threads REQUIRED)
 target_link_libraries(wiplib PRIVATE Threads::Threads)
 
+# Optional external libraries
+if(WIN32)
+  # Typical installation paths for prebuilt Windows binaries
+  set(OPENSSL_ROOT_DIR
+      "C:/OpenSSL-Win64"
+      "C:/Program Files/OpenSSL-Win64"
+      CACHE PATH "OpenSSL installation root")
+  set(BOOST_ROOT
+      "C:/local/boost_1_84_0"
+      CACHE PATH "Boost installation root")
+endif()
+
+find_package(OpenSSL QUIET)
+if(OpenSSL_FOUND)
+  target_link_libraries(wiplib PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+else()
+  message(STATUS "OpenSSL not found; continuing without SSL support")
+endif()
+
+find_package(Boost QUIET)
+if(Boost_FOUND)
+  target_link_libraries(wiplib PRIVATE Boost::boost)
+else()
+  message(STATUS "Boost not found; continuing without Boost")
+endif()
+
 # Platform-specific socket libraries
 if(WIN32)
     target_link_libraries(wiplib PRIVATE ws2_32 wsock32)

--- a/docs/windows_libraries.md
+++ b/docs/windows_libraries.md
@@ -1,0 +1,17 @@
+# Windows向け依存ライブラリ
+
+WIP の C++ コンポーネントで将来的に利用予定の外部ライブラリについて、
+Windows での入手方法と `find_package` が探索するパスの設定方法をまとめる。
+
+## Boost
+- **バイナリ配布**: 公式の [boost-binaries](https://sourceforge.net/projects/boost/files/boost-binaries/) で各バージョンの Windows 用ビルドが提供されている。`choco install boost` や `vcpkg install boost` でも取得可能。
+- **CMake での検出**: `BOOST_ROOT` 環境変数、または `-DBOOST_ROOT=C:/local/boost_1_84_0` のようにパスを指定する。
+- **見つからない場合**: `bootstrap.bat` → `b2` でソースからビルドする。代替としては `asio` 単体版の利用を検討する。
+
+## OpenSSL
+- **バイナリ配布**: [slproweb](https://slproweb.com/products/Win32OpenSSL.html) が Win32/Win64 向けのインストーラを提供。`choco install openssl` や `vcpkg install openssl` も利用可能。
+- **CMake での検出**: `OPENSSL_ROOT_DIR` に `C:/OpenSSL-Win64` などのインストール先を設定する。
+  例: `cmake -S cpp -B build -DOPENSSL_ROOT_DIR=C:/OpenSSL-Win64`
+- **見つからない場合**: ソースから `perl Configure` → `nmake` でビルドする。軽量代替として [LibreSSL](https://www.libressl.org/) の利用も可能。
+
+これらのパスは `cpp/CMakeLists.txt` でデフォルト値を設定しており、必要に応じて上書きできる。


### PR DESCRIPTION
## Summary
- detect Boost and OpenSSL on Windows with default search paths
- document where to obtain Windows binaries for Boost/OpenSSL and how to set find_package paths

## Testing
- `cmake -S cpp -B cpp/build -DCMAKE_BUILD_TYPE=Release` (fails: Cannot find source file src/packet/debug/debug_logger.cpp)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a583f0a31c83228c561b01050f4def