### PR TITLE
CI: Windows および Linux ビルドテストを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure
+        run: cmake -S . -B build
+      - name: Build
+        run: cmake --build build
+      - name: Test
+        run: ctest --test-dir build
+
+  build-windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure
+        run: cmake -S . -B build
+      - name: Build
+        run: cmake --build build
+      - name: Test
+        run: ctest --test-dir build


### PR DESCRIPTION
## Summary
- GitHub Actions の CI ワークフローを追加し、Windows / Linux 上で CMake ビルドとテストを実行

## Testing
- `pytest` (テストなし)


------
https://chatgpt.com/codex/tasks/task_e_68a5847fbff083229e407537d85a7151