### PR TITLE
fix: send auth_hash as raw UTF-8 bytes

### DIFF
--- a/Rust/src/wip_common_rs/packet/core/extended_field.rs
+++ b/Rust/src/wip_common_rs/packet/core/extended_field.rs
@@ -379,15 +379,10 @@ fn encode_value(key: &str, v: &FieldValue) -> (Vec<u8>, String) {
                 }
             }
         }
-        // auth_hash は16進文字列をバイト列に変換して送信（長さプレフィックスなし）
+        // auth_hash は文字列のUTF-8バイト列をそのまま送信（長さプレフィックスなし）
         "auth_hash" => {
             if let FieldValue::String(s) = v {
-                if let Ok(bytes) = hex::decode(s) {
-                    return (bytes, "auth_hash".into());
-                } else {
-                    // hex decodeに失敗した場合は文字列として送信
-                    return (s.as_bytes().to_vec(), "auth_hash".into());
-                }
+                return (s.as_bytes().to_vec(), "auth_hash".into());
             }
         }
         _ => {}


### PR DESCRIPTION
## Summary
- send `auth_hash` fields using the string's UTF-8 bytes without hex decoding

## Testing
- `cargo build` *(fails: failed to download from https://index.crates.io/config.json (403))*

------
https://chatgpt.com/codex/tasks/task_e_68a80fa9de18832293173efcf97e84f4