### PR TITLE
feat: handle extended fields in query packets

### DIFF
--- a/Rust/src/wip_common_rs/packet/types/query_packet.rs
+++ b/Rust/src/wip_common_rs/packet/types/query_packet.rs
@@ -1,8 +1,13 @@
 use bitvec::prelude::*;
 use std::time::{SystemTime, UNIX_EPOCH};
+use std::collections::HashMap;
 use crate::wip_common_rs::packet::core::checksum::{calc_checksum12, verify_checksum12};
 use crate::wip_common_rs::packet::core::bit_utils::{bytes_to_u128_le, u128_to_bytes_le, PacketFields};
 use crate::wip_common_rs::packet::core::format_base::JsonPacketSpecLoader;
+use crate::wip_common_rs::packet::core::extended_field::{
+    ExtendedFieldManager, FieldDefinition, FieldType, FieldValue,
+    pack_ext_fields, unpack_ext_fields
+};
 use once_cell::sync::Lazy;
 
 // JSON仕様からフィールド定義を構築（コンパイル時埋め込み）
@@ -33,6 +38,7 @@ pub struct QueryRequest {
     pub timestamp: u64,
     pub day: u8,
     pub area_code: u32,
+    pub ex_field: Option<ExtendedFieldManager>,
 }
 
 impl QueryRequest {
@@ -63,6 +69,7 @@ impl QueryRequest {
             timestamp,
             day: day & 0x07,
             area_code: area_code & 0xFFFFF,
+            ex_field: None,
         }
     }
 
@@ -90,6 +97,7 @@ impl QueryRequest {
             timestamp,
             day: day & 0x07,
             area_code: area_code & 0xFFFFF,
+            ex_field: None,
         }
     }
 
@@ -125,6 +133,58 @@ impl QueryRequest {
         s
     }
 
+    /// バイト列から QueryRequest を生成する
+    pub fn from_bytes(data: &[u8]) -> Option<Self> {
+        if data.len() < 16 {
+            return None;
+        }
+        let bits = BitSlice::<u8, Lsb0>::from_slice(&data[..16]);
+        let version: u8 = bits[0..4].load();
+        let packet_id: u16 = bits[4..16].load();
+        let weather_flag = bits[19];
+        let temperature_flag = bits[20];
+        let pop_flag = bits[21];
+        let alert_flag = bits[22];
+        let disaster_flag = bits[23];
+        let ex_flag = bits[24];
+        let day: u8 = bits[27..30].load();
+        let timestamp: u64 = bits[32..96].load();
+        let area_code: u32 = bits[96..116].load();
+
+        // 拡張フィールド
+        let ex_field = if ex_flag && data.len() > 16 {
+            let map = unpack_ext_fields(&data[16..]);
+            if map.is_empty() {
+                None
+            } else {
+                let mut mgr = ExtendedFieldManager::new();
+                for (k, v) in map {
+                    let def = FieldDefinition::new(k.clone(), v.get_type());
+                    mgr.add_definition(def);
+                    let _ = mgr.set_value(k, v);
+                }
+                Some(mgr)
+            }
+        } else {
+            None
+        };
+
+        Some(Self {
+            version,
+            packet_id,
+            weather_flag,
+            temperature_flag,
+            pop_flag,
+            alert_flag,
+            disaster_flag,
+            ex_flag,
+            timestamp,
+            day,
+            area_code,
+            ex_field,
+        })
+    }
+
     pub fn get_packet_id(&self) -> u16 {
         self.packet_id
     }
@@ -139,7 +199,7 @@ impl QueryRequest {
 
     /// パケットをバイト列に変換する (Little Endian)
     /// Python実装と互換性を保つため、手動でビットフィールドを配置
-    pub fn to_bytes(&self) -> [u8; 16] {
+    pub fn to_bytes(&self) -> Vec<u8> {
         let mut out = [0u8; 16];
         let mut bits_u128 = 0u128;
 
@@ -179,7 +239,7 @@ impl QueryRequest {
         }
         
         // bit 24: ex_flag (1ビット)
-        if self.ex_flag {
+        if self.ex_flag || self.ex_field.is_some() {
             bits_u128 |= 1u128 << 24;
         }
         
@@ -202,14 +262,26 @@ impl QueryRequest {
         // バイト配列に変換
         u128_to_bytes_le(bits_u128, &mut out);
 
-        // チェックサム計算（ヘッダ16バイト）
-        let checksum = calc_checksum12(&out);
+        let mut packet = out.to_vec();
+
+        // 拡張フィールドを追加
+        if let Some(ext) = &self.ex_field {
+            let mut map = HashMap::new();
+            for (k, v) in ext.get_all_values() {
+                map.insert(k.clone(), v.clone());
+            }
+            let ext_bytes = pack_ext_fields(&map);
+            packet.extend_from_slice(&ext_bytes);
+        }
+
+        // チェックサム計算（パケット全体）
+        let checksum = calc_checksum12(&packet);
 
         // チェックサム設定 (bit 116-127)
         bits_u128 |= ((checksum as u128) & 0x0FFF) << 116;
-        u128_to_bytes_le(bits_u128, &mut out);
+        u128_to_bytes_le(bits_u128, &mut packet[..16]);
 
-        out
+        packet
     }
 }
 
@@ -222,6 +294,7 @@ pub struct QueryResponse {
     pub weather_code: Option<u16>,
     pub temperature: Option<i8>,
     pub precipitation: Option<u8>,
+    pub ex_field: Option<ExtendedFieldManager>,
 }
 
 impl QueryResponse {
@@ -232,7 +305,6 @@ impl QueryResponse {
             return None;
         }
         let bits = BitSlice::<u8, Lsb0>::from_slice(&data[..20]);
-        let header = &data[..16];
 
         // チェックサム検証をスキップ（Python/Rust相互運用性のため）
         // 注意: チェックサム算法の違いは既知の問題で、将来修正予定
@@ -241,6 +313,7 @@ impl QueryResponse {
         let version: u8  = bits[0..4].load();
         let packet_id: u16 = bits[4..16].load();
         let area_code: u32 = bits[96..116].load();
+        let ex_flag = bits[24];
         let weather_code: u16 = bits[128..144].load();
         let temp_raw: u8    = bits[144..152].load();
         let precip: u8      = bits[152..160].load();
@@ -259,6 +332,24 @@ impl QueryResponse {
         };
         let precipitation = if precip != 0 { Some(precip) } else { None };
 
+        // 拡張フィールド
+        let ex_field = if ex_flag && data.len() > 20 {
+            let map = unpack_ext_fields(&data[20..]);
+            if map.is_empty() {
+                None
+            } else {
+                let mut mgr = ExtendedFieldManager::new();
+                for (k, v) in map {
+                    let def = FieldDefinition::new(k.clone(), v.get_type());
+                    mgr.add_definition(def);
+                    let _ = mgr.set_value(k, v);
+                }
+                Some(mgr)
+            }
+        } else {
+            None
+        };
+
         Some(Self {
             version,
             packet_id,
@@ -266,6 +357,7 @@ impl QueryResponse {
             weather_code,
             temperature,
             precipitation,
+            ex_field,
         })
     }
 }
@@ -273,6 +365,7 @@ impl QueryResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn request_to_bytes_length() {
@@ -290,22 +383,31 @@ mod tests {
         bits[128..144].store(10u16);
         bits[144..152].store(120u8);
         bits[152..160].store(80u8);
-        let mut data = [0u8; 20];
-        data.copy_from_slice(bits.as_raw_slice());
+        let mut base = [0u8; 20];
+        base.copy_from_slice(bits.as_raw_slice());
+
+        // 拡張フィールドを追加
+        let mut map = HashMap::new();
+        map.insert("alert".to_string(), FieldValue::String("A,B".into()));
+        map.insert("disaster".to_string(), FieldValue::String("X".into()));
+        let ext = pack_ext_fields(&map);
+        let mut packet = Vec::new();
+        packet.extend_from_slice(&base);
+        packet.extend_from_slice(&ext);
 
         // ヘッダ部（最初の16バイト）にチェックサムを埋め込む
-        let checksum = calc_checksum12(&data[..16]);
-        let mut head_bits = bitvec![u8, Lsb0; 0; 128];
-        head_bits.copy_from_bitslice(&BitSlice::<u8, Lsb0>::from_slice(&data[..16]));
+        let checksum = calc_checksum12(&packet);
+        let mut head_bits = BitSlice::<u8, Lsb0>::from_slice_mut(&mut packet[..16]);
         head_bits[116..128].store(checksum);
-        let mut head = [0u8; 16];
-        head.copy_from_slice(head_bits.as_raw_slice());
-        data[..16].copy_from_slice(&head);
-        let resp = QueryResponse::from_bytes(&data).unwrap();
+
+        let resp = QueryResponse::from_bytes(&packet).unwrap();
         assert_eq!(resp.packet_id, 1);
         assert_eq!(resp.area_code, 123);
         assert_eq!(resp.weather_code, Some(10));
         assert_eq!(resp.temperature, Some(20i8));
         assert_eq!(resp.precipitation, Some(80u8));
+        let ext = resp.ex_field.expect("ext");
+        assert_eq!(ext.get_value("alert"), Some(&FieldValue::String("A,B".into())));
+        assert_eq!(ext.get_value("disaster"), Some(&FieldValue::String("X".into())));
     }
 }


### PR DESCRIPTION
## Summary
- support extended fields on QueryRequest/QueryResponse with pack/unpack helpers
- expose alert/disaster data in Python-compatible client

## Testing
- `cargo test` *(fails: failed to download crates index)*
- `cargo test --offline` *(fails: no matching package named `bitvec` found)*

------
https://chatgpt.com/codex/tasks/task_e_68a86a25fd5083229ab34a8940cdcaa0