### PR TITLE
Use location server for coordinate weather lookup

### DIFF
--- a/Rust/src/bin/wip-weather.rs
+++ b/Rust/src/bin/wip-weather.rs
@@ -1,5 +1,7 @@
 use clap::{Parser, Subcommand};
-use std::error::Error;
+use log::debug;
+use std::{env, error::Error};
+use wip_rust::wip_common_rs::clients::location_client::{LocationClient, LocationClientImpl};
 use wip_rust::wip_common_rs::clients::weather_client::WeatherClient;
 
 #[derive(Parser)]
@@ -182,15 +184,39 @@ async fn main() -> Result<(), Box<dyn Error>> {
             disaster,
             day,
         } => {
-            // 座標から気象データを取得する場合は、まず座標をLocationRequestで送信する必要がある
+            // 座標から気象データを取得する場合は、位置解決サービスを使用する
             println!("座標 ({:.4}, {:.4}) から気象データを取得中...", latitude, longitude);
             println!("注意: この機能には位置解決サービスとの連携が必要です");
 
-            // 今のところ、座標から直接エリアコードを推定（簡易実装）
-            let estimated_area_code = estimate_area_code_from_coords(latitude, longitude);
-            println!("推定エリアコード: {}", estimated_area_code);
+            let loc_host = env::var("LOCATION_SERVER_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+            let loc_port = env::var("LOCATION_SERVER_PORT")
+                .ok()
+                .and_then(|v| v.parse::<u16>().ok())
+                .unwrap_or(4109);
+            debug!("Location server: {}:{}", loc_host, loc_port);
 
-            match client.get_weather_simple(estimated_area_code, weather, temperature, precipitation, alerts, disaster, day)? {
+            let loc_client = match LocationClientImpl::new(&loc_host, loc_port).await {
+                Ok(c) => c,
+                Err(e) => {
+                    println!("❌ Locationクライアントの初期化に失敗しました: {}", e);
+                    return Ok(());
+                }
+            };
+
+            let area_code = match loc_client.resolve_coordinates(latitude, longitude).await {
+                Ok(code) => {
+                    debug!("Resolved area code: {}", code);
+                    code
+                }
+                Err(e) => {
+                    println!("❌ 座標の解決に失敗しました: {}", e);
+                    return Ok(());
+                }
+            };
+
+            println!("取得エリアコード: {}", area_code);
+
+            match client.get_weather_simple(area_code, weather, temperature, precipitation, alerts, disaster, day)? {
                 Some(response) => {
                     print_weather_response(&response);
                 }
@@ -237,20 +263,4 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     Ok(())
-}
-
-// 簡易的な座標からエリアコード推定（実際には位置解決サービスを使用）
-fn estimate_area_code_from_coords(lat: f64, lng: f64) -> u32 {
-    // 日本の主要都市の座標範囲からエリアコードを推定
-    if lat >= 35.6 && lat <= 35.8 && lng >= 139.6 && lng <= 139.8 {
-        11000 // 東京
-    } else if lat >= 34.6 && lat <= 34.8 && lng >= 135.4 && lng <= 135.6 {
-        12000 // 大阪（仮想エリアコード）
-    } else if lat >= 43.0 && lat <= 43.1 && lng >= 141.3 && lng <= 141.4 {
-        13000 // 札幌（仮想エリアコード）
-    } else if lat >= 33.5 && lat <= 33.7 && lng >= 130.3 && lng <= 130.5 {
-        14000 // 福岡（仮想エリアコード）
-    } else {
-        11000 // デフォルトは東京
-    }
 }


### PR DESCRIPTION
## Summary
- resolve coordinates via `LocationClientImpl` in weather client
- read location server host/port from `LOCATION_SERVER_HOST` and `LOCATION_SERVER_PORT`
- add debug logging and error handling for coordinate resolution

## Testing
- `cargo test` *(fails: failed to download from https://index.crates.io/config.json (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68a892879df88322a9e785d93a70a61e