### PR TITLE
feat: add alert and disaster flags

### DIFF
--- a/Rust/src/bin/wip-weather.rs
+++ b/Rust/src/bin/wip-weather.rs
@@ -133,7 +133,17 @@ fn print_weather_response(response: &wip_rust::wip_common_rs::packet::types::que
         println!("降水確率: {}%", precipitation);
     }
 
-    // Note: alert_flag and disaster_flag are not available in current QueryResponse struct
+    if let Some(alerts) = response.get_alert() {
+        if !alerts.is_empty() {
+            println!("警報: {}", alerts.join(", "));
+        }
+    }
+
+    if let Some(disaster) = response.get_disaster() {
+        if !disaster.is_empty() {
+            println!("災害情報: {}", disaster.join(", "));
+        }
+    }
 }
 
 #[tokio::main]


### PR DESCRIPTION
## Summary
- add alert and disaster flags to QueryResponse and wire them into serialization
- show alert and disaster information in CLI client
- extend tests for new QueryResponse flags

## Testing
- `cargo test` *(fails: failed to download from crates.io: [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68a8937493a08322aaf631b0e8673be1