### PR TITLE
feat: align weather port defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ WIP（Weather Transfer Protocol）は、NTPをベースとした軽量な気象�
 ## 概要
 
 - **プロトコル**: NTPベースのUDPアプリケーションプロトコル
-- **ポート番号**: UDP/4110
+- **ポート番号**: UDP/4110（Rust/Python共通）
 - **データサイズ**: 基本16バイト程度の軽量パケット
 - **通信方式**: 1:1のリクエスト・レスポンス形式
 - **データソース**: 気象庁公開データ（XML/JSON形式）
@@ -38,7 +38,7 @@ WIP（Weather Transfer Protocol）は、NTPをベースとした軽量な気象�
 
 ### サーバ構成
 
-1. **Weather Server (Port 4110)** - プロキシサーバ
+1. **Weather Server (Port 4110)** - プロキシサーバ（Rust/Python共通ポート）
    - クライアントからのリクエストを受信
    - 適切なサーバへリクエストを転送
    - レスポンスをクライアントに返送
@@ -151,7 +151,7 @@ pip install "wiplib[all]"
 `.env`ファイルを作成し、以下を設定：
 ```env
 # サーバ設定
-WEATHER_SERVER_PORT=4110
+WEATHER_SERVER_PORT=4110  # Rust/Python共通
 LOCATION_RESOLVER_HOST=localhost
 LOCATION_RESOLVER_PORT=4109
 QUERY_GENERATOR_HOST=localhost

--- a/Rust/docs/COMMAND_REFERENCE.md
+++ b/Rust/docs/COMMAND_REFERENCE.md
@@ -666,7 +666,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```bash
 # .env ファイル例
 WIP_SERVER_HOST=127.0.0.1
-WIP_WEATHER_PORT=4110
+WIP_WEATHER_PORT=4110  # Rust/Python共通
 WIP_LOCATION_PORT=4109
 WIP_QUERY_PORT=4111
 WIP_REPORT_PORT=4112

--- a/Rust/src/bin/wip-cli.rs
+++ b/Rust/src/bin/wip-cli.rs
@@ -42,8 +42,8 @@ enum Commands {
     /// 気象データサービス (ポート 4110)
     #[command(alias = "w")]
     Weather {
-        /// サーバーポート
-        #[arg(short, long, default_value = "4111")]
+        /// サーバーポート (デフォルト: 4110)
+        #[arg(short, long, default_value = "4110")]
         port: u16,
 
         #[command(subcommand)]

--- a/Rust/src/bin/wip-weather.rs
+++ b/Rust/src/bin/wip-weather.rs
@@ -11,8 +11,8 @@ struct Cli {
     #[arg(short = 'H', long, default_value = "127.0.0.1")]
     host: String,
 
-    /// サーバーポート
-    #[arg(short, long, default_value = "4111")]
+    /// サーバーポート (デフォルト: 4110)
+    #[arg(short, long, default_value = "4110")]
     port: u16,
 
     /// デバッグモード


### PR DESCRIPTION
## Summary
- set default weather port to 4110 in Rust CLI and weather client
- update docs/README with new port and note Python compatibility

## Testing
- `cargo test` *(fails: failed to download index.crates.io; CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a893d713c88322baef0fe70226e1cd