### PR TITLE
Add response authentication to report client

### DIFF
--- a/Rust/tests/test_report_client_auth.rs
+++ b/Rust/tests/test_report_client_auth.rs
@@ -35,6 +35,7 @@ async fn test_auth_hash_included_when_auth_enabled() {
         enable_debug: false,
         auth_enabled: true,
         auth_passphrase: Some("test_pass".into()),
+        response_auth_enabled: false,
     };
     let client = ReportClientImpl::with_config("127.0.0.1", server_port, config)
         .await


### PR DESCRIPTION
## Summary
- verify report server responses via auth_hash
- add response_auth_enabled and passphrase config loaded from env
- validate server responses in send_single_report

## Testing
- `cargo test --test test_report_client_auth`
- `cargo test` *(fails: packet_format_golden_tests.rs mismatched types)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4b82a79c8322bec7fb112905442e