### PR TITLE
feat: add persistent cache for location client

### DIFF
--- a/Rust/docs/COMMAND_REFERENCE.md
+++ b/Rust/docs/COMMAND_REFERENCE.md
@@ -299,7 +299,8 @@ async fn configured_location_client() -> Result<(), Box<dyn std::error::Error>> 
         bounds: CoordinateBounds::japan(), // 日本国内のみ
         enable_validation: true,
         cache_enabled: true,
-        cache_ttl: Duration::from_hours(1),
+        cache_ttl: Duration::from_secs(3600),
+        ..Default::default()
     };
     
     let mut location_client = LocationClient::with_config("127.0.0.1:4109".parse()?, config).await?;


### PR DESCRIPTION
## Summary
- add cache file path and persistent flag to `LocationClientConfig`
- load and periodically save coordinate cache using Python-compatible `coordinate_cache.json`
- update docs for new config defaults

## Testing
- `cargo test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4b902e688322bf45aa3dfac65623