### PR TITLE
Add proxy flag to get_weather and basic test

### DIFF
--- a/Rust/README.md
+++ b/Rust/README.md
@@ -71,7 +71,10 @@ use wip_rust::wip_common_rs::client::WipClient;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut client = WipClient::new("127.0.0.1", 4111, 4109, 4111, 4112, false).await?;
     client.set_area_code(11000);
-    if let Some(resp) = client.get_weather(true, true, true, false, false, 0).await? {
+    if let Some(resp) = client
+        .get_weather(true, true, true, false, false, 0, true)
+        .await?
+    {
         if let Some(temp) = resp.temperature {
             println!("Temperature: {}°C", temp);
         }

--- a/Rust/examples/wip_client.rs
+++ b/Rust/examples/wip_client.rs
@@ -8,7 +8,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // エリアコードを設定して気象データを取得
     client.set_area_code(11000);
-    if let Some(resp) = client.get_weather(true, true, true, false, false, 0).await? {
+    if let Some(resp) = client
+        .get_weather(true, true, true, false, false, 0, true)
+        .await?
+    {
         println!("Area Code: {}", resp.area_code);
     }
 

--- a/Rust/src/bin/wip-weather.rs
+++ b/Rust/src/bin/wip-weather.rs
@@ -189,7 +189,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         } => {
             println!("エリアコード {} の気象データを取得中...", area_code);
             client.set_area_code(area_code);
-            match client.get_weather(weather, temperature, precipitation, alerts, disaster, day).await? {
+            match client
+                .get_weather(weather, temperature, precipitation, alerts, disaster, day, true)
+                .await?
+            {
                 Some(response) => {
                     print_weather_response(&response);
                 }
@@ -241,7 +244,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
             println!("取得エリアコード: {}", area_code);
             client.set_area_code(area_code);
-            match client.get_weather(weather, temperature, precipitation, alerts, disaster, day).await? {
+            match client
+                .get_weather(weather, temperature, precipitation, alerts, disaster, day, true)
+                .await?
+            {
                 Some(response) => {
                     print_weather_response(&response);
                 }
@@ -265,7 +271,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 println!("\n--- {} ---", day_name);
 
                 client.set_area_code(area_code);
-                match client.get_weather(true, true, true, false, false, day).await? {
+                match client
+                    .get_weather(true, true, true, false, false, day, true)
+                    .await?
+                {
                     Some(response) => {
                         if let Some(weather_code) = response.weather_code {
                             println!("天気: {}", weather_code_to_string(weather_code));

--- a/Rust/tests/test_wip_client.rs
+++ b/Rust/tests/test_wip_client.rs
@@ -1,0 +1,21 @@
+use wip_rust::wip_common_rs::client::WipClient;
+
+#[tokio::test]
+async fn test_get_weather_proxy_flag() {
+    let mut client = WipClient::new("127.0.0.1", 0, 0, 0, 0, false)
+        .await
+        .unwrap();
+    client.set_area_code(130010);
+    assert!(
+        client
+            .get_weather(true, true, true, false, false, 0, true)
+            .await
+            .is_err()
+    );
+    assert!(
+        client
+            .get_weather(true, true, true, false, false, 0, false)
+            .await
+            .is_err()
+    );
+}


### PR DESCRIPTION
## Summary
- add `proxy` flag to `WipClient::get_weather` to choose WeatherClient or direct QueryClient path
- update examples and CLI to use new argument
- add simple test for proxy flag

## Testing
- `cargo test --test test_wip_client -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68ac4b95e0988322a8b7ff1aaeb6cdb7