### PR TITLE
Remove async from PythonCompatibleWeatherClient::get_weather_simple

### DIFF
--- a/Rust/src/wip_common_rs/clients/python_compatible_client.rs
+++ b/Rust/src/wip_common_rs/clients/python_compatible_client.rs
@@ -187,7 +187,7 @@ impl PythonCompatibleWeatherClient {
     /// ```python
     /// def get_weather_simple(self, area_code, include_all=False, day=0):
     /// ```
-    pub async fn get_weather_simple(
+    pub fn get_weather_simple(
         &mut self,
         area_code: u32,
         include_all: Option<bool>,


### PR DESCRIPTION
## Summary
- make PythonCompatibleWeatherClient::get_weather_simple synchronous

## Testing
- `cargo test` *(fails: download of config.json failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4bb84fe88322af702be538f0f06b