### PR TITLE
Improve cache statistics reporting

### DIFF
--- a/Rust/src/wip_common_rs/clients/python_compatible_client.rs
+++ b/Rust/src/wip_common_rs/clients/python_compatible_client.rs
@@ -384,9 +384,18 @@ impl PythonCompatibleLocationClient {
     pub fn get_cache_stats(&self) -> HashMap<String, serde_json::Value> {
         let mut stats = HashMap::new();
         stats.insert("enabled".to_string(), serde_json::Value::Bool(self.cache_enabled));
-        stats.insert("ttl_minutes".to_string(), serde_json::Value::Number(serde_json::Number::from(self.cache_ttl_minutes)));
-        stats.insert("hits".to_string(), serde_json::Value::Number(serde_json::Number::from(0))); // TODO: 実装
-        stats.insert("misses".to_string(), serde_json::Value::Number(serde_json::Number::from(0))); // TODO: 実装
+        stats.insert(
+            "ttl_minutes".to_string(),
+            serde_json::Value::Number(serde_json::Number::from(self.cache_ttl_minutes)),
+        );
+
+        for (key, value) in self.inner_client.get_cache_stats() {
+            stats.insert(
+                key,
+                serde_json::Value::Number(serde_json::Number::from(value as u64)),
+            );
+        }
+
         stats
     }
 }


### PR DESCRIPTION
## Summary
- Use real cache and stat data in `LocationClientImpl::get_cache_stats`
- Expose inner client's cache stats via `PythonCompatibleLocationClient::get_cache_stats`

## Testing
- `cargo test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4bc3f30c8322873a1d3b968c8973