### PR TITLE
Use dotenvy for host and port defaults in Rust CLI tools

### DIFF
--- a/Rust/Cargo.toml
+++ b/Rust/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = "0.1"
 dashmap = "6.0"
 log = "0.4"
 env_logger = "0.11"
+dotenvy = "0.15"
 once_cell = "1.19"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"

--- a/Rust/src/bin/wip-report.rs
+++ b/Rust/src/bin/wip-report.rs
@@ -1,5 +1,16 @@
 use clap::{Parser, Subcommand};
-use std::error::Error;
+use std::{env, error::Error};
+
+fn default_host() -> String {
+    env::var("REPORT_SERVER_HOST").unwrap_or_else(|_| "127.0.0.1".to_string())
+}
+
+fn default_port() -> u16 {
+    env::var("REPORT_SERVER_PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(4112)
+}
 use wip_rust::wip_common_rs::client::WipClient;
 use wip_rust::wip_common_rs::packet::types::report_packet::{ReportRequest, ReportResponse};
 
@@ -9,11 +20,11 @@ use wip_rust::wip_common_rs::packet::types::report_packet::{ReportRequest, Repor
 #[command(version = "0.1.0")]
 struct Cli {
     /// サーバーホスト
-    #[arg(short = 'H', long, default_value = "127.0.0.1")]
+    #[arg(short = 'H', long, default_value_t = default_host())]
     host: String,
 
     /// サーバーポート
-    #[arg(short, long, default_value = "4112")]
+    #[arg(short, long, default_value_t = default_port())]
     port: u16,
 
     /// デバッグモード
@@ -326,6 +337,7 @@ async fn send_test_reports(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+    dotenvy::dotenv().ok();
     let cli = Cli::parse();
 
     if cli.debug {


### PR DESCRIPTION
## Summary
- load environment variables using `dotenvy`
- default server host and port for weather and report clients come from env vars

## Testing
- `cargo test` *(failed: failed to download from crates.io: [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68ac4c00ffa883228f08552dc5850ae8