### PR TITLE
feat: allow env defaults for report client

### DIFF
--- a/Rust/src/bin/wip-report.rs
+++ b/Rust/src/bin/wip-report.rs
@@ -1,7 +1,18 @@
 use clap::{Parser, Subcommand};
-use std::error::Error;
+use std::{env, error::Error};
 use wip_rust::wip_common_rs::client::WipClient;
 use wip_rust::wip_common_rs::packet::types::report_packet::{ReportRequest, ReportResponse};
+
+fn default_host() -> String {
+    env::var("REPORT_SERVER_HOST").unwrap_or_else(|_| "127.0.0.1".to_string())
+}
+
+fn default_port() -> u16 {
+    env::var("REPORT_SERVER_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(4112)
+}
 
 #[derive(Parser)]
 #[command(name = "wip-report")]
@@ -9,11 +20,11 @@ use wip_rust::wip_common_rs::packet::types::report_packet::{ReportRequest, Repor
 #[command(version = "0.1.0")]
 struct Cli {
     /// サーバーホスト
-    #[arg(short = 'H', long, default_value = "127.0.0.1")]
+    #[arg(short = 'H', long, default_value_t = default_host())]
     host: String,
 
     /// サーバーポート
-    #[arg(short, long, default_value = "4112")]
+    #[arg(short, long, default_value_t = default_port())]
     port: u16,
 
     /// デバッグモード


### PR DESCRIPTION
## Summary
- read REPORT_SERVER_HOST and REPORT_SERVER_PORT for default server settings in wip-report

## Testing
- `cargo test --locked --offline` *(fails: no matching package named `bitvec` found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4c180c8083229d46ab5a35faed78