### PR TITLE
Remove auth_token from CLI structs

### DIFF
--- a/Rust/src/bin/wip-cli.rs
+++ b/Rust/src/bin/wip-cli.rs
@@ -29,10 +29,6 @@ struct Cli {
     #[arg(short, long, global = true)]
     debug: bool,
 
-    /// 認証トークン
-    #[arg(short, long, global = true)]
-    auth_token: Option<String>,
-
     #[command(subcommand)]
     command: Commands,
 }
@@ -279,7 +275,6 @@ enum AuthCommands {
 async fn run_weather_command(
     host: &str,
     port: u16,
-    auth_token: Option<String>,
     debug: bool,
     command: WeatherCommands,
 ) -> Result<(), Box<dyn Error>> {
@@ -291,10 +286,6 @@ async fn run_weather_command(
 
     if debug {
         cmd.arg("-d");
-    }
-
-    if let Some(token) = auth_token {
-        cmd.args(&["-a", &token]);
     }
 
     match command {
@@ -430,7 +421,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     .and_then(|p| p.parse().ok())
                     .unwrap_or(4110)
             });
-            run_weather_command(&default_host, port, cli.auth_token, cli.debug, command).await?;
+            run_weather_command(&default_host, port, cli.debug, command).await?;
         }
 
         Commands::Location { port, command } => {

--- a/Rust/src/bin/wip-location.rs
+++ b/Rust/src/bin/wip-location.rs
@@ -19,10 +19,6 @@ struct Cli {
     #[arg(short, long)]
     debug: bool,
 
-    /// 認証トークン
-    #[arg(short, long)]
-    auth_token: Option<String>,
-
     #[command(subcommand)]
     command: Commands,
 }
@@ -155,10 +151,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let server_addr = format!("{}:{}", cli.host, cli.port);
     let client = LocationClientImpl::new(&cli.host, cli.port).await?;
-
-    if let Some(_token) = cli.auth_token {
-        println!("⚠️ 認証トークン機能は現在実装中です");
-    }
 
     match cli.command {
         Commands::Resolve { latitude, longitude, verbose } => {

--- a/Rust/src/bin/wip-query.rs
+++ b/Rust/src/bin/wip-query.rs
@@ -19,10 +19,6 @@ struct Cli {
     #[arg(short, long)]
     debug: bool,
 
-    /// 認証トークン
-    #[arg(short, long)]
-    auth_token: Option<String>,
-
     #[command(subcommand)]
     command: Commands,
 }
@@ -194,10 +190,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let server_addr = format!("{}:{}", cli.host, cli.port);
     let client = QueryClientImpl::new(&cli.host, cli.port).await?;
-
-    if let Some(_token) = cli.auth_token {
-        println!("⚠️ 認証トークン機能は現在実装中です");
-    }
 
     match cli.command {
         Commands::Status { region, verbose } => {

--- a/Rust/src/bin/wip-report.rs
+++ b/Rust/src/bin/wip-report.rs
@@ -20,10 +20,6 @@ struct Cli {
     #[arg(short, long)]
     debug: bool,
 
-    /// 認証トークン
-    #[arg(short, long)]
-    auth_token: Option<String>,
-
     #[command(subcommand)]
     command: Commands,
 }
@@ -333,10 +329,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     }
 
     let client = WipClient::new(&cli.host, 4111, 4109, 4111, cli.port, cli.debug).await?;
-
-    if let Some(_token) = cli.auth_token {
-        println!("⚠️ 認証トークン機能は現在実装中です");
-    }
 
     match cli.command {
         Commands::Disaster {

--- a/Rust/src/bin/wip-weather.rs
+++ b/Rust/src/bin/wip-weather.rs
@@ -21,10 +21,6 @@ struct Cli {
     #[arg(short, long)]
     debug: bool,
 
-    /// 認証トークン
-    #[arg(short, long)]
-    auth_token: Option<String>,
-
     #[command(subcommand)]
     command: Commands,
 }
@@ -172,10 +168,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let port = cli.port.unwrap_or(env_port);
 
     let mut client = WipClient::new(&host, port, 4109, port, 4112, cli.debug).await?;
-
-    if let Some(_token) = cli.auth_token {
-        println!("⚠️ 認証トークン機能は現在実装中です");
-    }
 
     match cli.command {
         Commands::Get {


### PR DESCRIPTION
## Summary
- drop unused `auth_token` field from all CLI binaries
- simplify `wip-cli` weather command helpers accordingly

## Testing
- `cargo test` *(fails: cargo command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4c35804083229d8e45093db77c22