### PR TITLE
Remove debug logger source from build

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -45,7 +45,6 @@ set(WIPLIB_SRC
     src/utils/env.cpp
     src/utils/network.cpp
     src/utils/platform_compat.cpp
-    src/packet/debug/debug_logger.cpp
     # Temporarily disabled due to build errors
     # src/utils/redis_log_handler.cpp
     # src/compatibility/python_errors.cpp


### PR DESCRIPTION
## Summary
- remove `src/packet/debug/debug_logger.cpp` from `WIPLIB_SRC` list

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b3fdfa5fec8322be13a33dd085cb7b