### PR TITLE
chore: set CMP0167 policy in CMake

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 3.20)
 
+# Silence CMake warning CMP0167 about FindBoost behavior when available
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif()
+
 project(wiplib_cpp VERSION 0.1.0 LANGUAGES CXX)
 
 option(WIPLIB_BUILD_TESTS "Build tests" OFF)


### PR DESCRIPTION
## Summary
- set CMP0167 to NEW in `cpp/CMakeLists.txt` to silence FindBoost policy warning

## Testing
- `cmake -S . -B build` *(fails: Cannot find source file src/packet/debug/debug_logger.cpp but no CMP0167 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fe06590083228cb6b31e6a7c7271