### PR TITLE
ScheduledWeatherReporterで.envからレポートサーバー設定を読み込む

### DIFF
--- a/python/application/tools/scheduled_weather_reporter.py
+++ b/python/application/tools/scheduled_weather_reporter.py
@@ -21,6 +21,7 @@ import sys
 import signal
 from pathlib import Path
 from datetime import datetime
+from dotenv import load_dotenv
 
 # 近傍ユーティリティを利用
 current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -41,11 +42,11 @@ from WIPCommonPy.clients.report_client import ReportClient
 
 class ScheduledWeatherReporter:
     """定期実行天気レポーター"""
-    
+
     def __init__(self,
                  api_base_url: str = None,
-                 report_server_host: str = "wip.ncc.onl",
-                 report_server_port: int = 4112,
+                 report_server_host: str = os.getenv("REPORT_SERVER_HOST", "wip.ncc.onl"),
+                 report_server_port: int = int(os.getenv("REPORT_SERVER_PORT", 4112)),
                  debug: bool = False,
                  area_codes_path: str = None):
         """
@@ -58,6 +59,7 @@ class ScheduledWeatherReporter:
             debug: デバッグモード
             area_codes_path: エリアコード定義JSONのパス（docs/area_codes.json を既定）
         """
+        load_dotenv()
         self.running = True
         self.debug = debug
         


### PR DESCRIPTION
## Summary
- `.env` からレポートサーバーのホストとポートを読み込むように変更
- `ScheduledWeatherReporter` 初期化時に `load_dotenv()` を呼び出し、環境変数設定を反映

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b551267e288322a9eb8a67fb13e573