### PR TITLE
WeatherAPIReporter が .env からレポートサーバー設定を読み込むように修正

### DIFF
--- a/python/application/tools/weather_api_reporter.py
+++ b/python/application/tools/weather_api_reporter.py
@@ -16,19 +16,24 @@ import sys
 from typing import Dict, Any, List, Optional
 from datetime import datetime
 
+from dotenv import load_dotenv
+
 # WIPCommonPyをインポートするためのパス設定
 sys.path.insert(0, '/mnt/c/Users/ポッポ焼き/Desktop/WIP/src')
 
 from WIPCommonPy.clients.report_client import ReportClient
 
+# .env を読み込む
+load_dotenv()
+
 
 class WeatherAPIReporter:
     """外部APIから気象データを取得してレポートサーバーに送信するクラス"""
-    
-    def __init__(self, 
+
+    def __init__(self,
                  api_key: str = None,
-                 report_server_host: str = "wip.ncc.onl",
-                 report_server_port: int = 9999,
+                 report_server_host: str = os.getenv("REPORT_SERVER_HOST", "wip.ncc.onl"),
+                 report_server_port: int = int(os.getenv("REPORT_SERVER_PORT", 4112)),
                  debug: bool = False):
         """
         初期化


### PR DESCRIPTION
## 概要
- WeatherAPIReporter で `.env` を読み込むように修正
- `REPORT_SERVER_HOST` と `REPORT_SERVER_PORT` の環境変数を既定値として使用

## テスト
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b55131a9e08322bb78b343fd623fa9