### PR TITLE
Fix Redis key prefix and env var expansion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,7 @@ DB_PASSWORD=wippass
 # --- Dragonfly Settings ---
 REDIS_HOST=127.0.0.1
 REDIS_PORT=6379
-REDIS_KEY_PREFIX=
+REDIS_KEY_PREFIX=""
 # --- Log Dragonfly (for Map UI logs) ---
 LOG_REDIS_HOST=127.0.0.1
 LOG_REDIS_PORT=6380

--- a/src/WIPCommonPy/utils/config_loader.py
+++ b/src/WIPCommonPy/utils/config_loader.py
@@ -58,7 +58,7 @@ class ConfigLoader:
 
                     def replace_env(match):
                         env_var = match.group(1)
-                        return os.getenv(env_var, match.group(0))
+                        return os.getenv(env_var, "")
 
                     expanded_value = re.sub(pattern, replace_env, value)
                     self.config.set(section, key, expanded_value)

--- a/src/WIPServerPy/servers/report_server/report_server.py
+++ b/src/WIPServerPy/servers/report_server/report_server.py
@@ -444,12 +444,14 @@ class ReportServer(BaseServer):
 
             # キープレフィックス（テスト検証用）を環境変数/設定から取得
             # 優先順位: REPORT_DB_KEY_PREFIX > [database].key_prefix > REDIS_KEY_PREFIX
-            key_prefix = (
+            key_prefix = ""
+            prefix_candidate = (
                 os.getenv("REPORT_DB_KEY_PREFIX")
-                or self.config.get("database", "key_prefix", None)
-                or os.getenv("REDIS_KEY_PREFIX")
-                or ""
+                or self.config.get("database", "key_prefix", "")
+                or os.getenv("REDIS_KEY_PREFIX", "")
             )
+            if prefix_candidate and prefix_candidate != "${REDIS_KEY_PREFIX}":
+                key_prefix = prefix_candidate
 
             rm = WeatherRedisManager(debug=self.debug, key_prefix=key_prefix)
 


### PR DESCRIPTION
## Summary
- replace missing env vars with empty string in config loader
- guard against placeholder `${REDIS_KEY_PREFIX}` in ReportServer database key prefix
- define `REDIS_KEY_PREFIX` in env example

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b679d1884083229ad2a3c06c0d315b