### PR TITLE
Add raw packet option for landmarks retrieval

### DIFF
--- a/src/WIPClientPy/client_async.py
+++ b/src/WIPClientPy/client_async.py
@@ -10,7 +10,7 @@ from WIPCommonPy.utils.log_config import LoggerConfig, UnifiedLogFormatter
 from WIPCommonPy.clients.weather_client import WeatherClient
 from WIPCommonPy.clients.location_client import LocationClient
 from WIPCommonPy.clients.query_client import QueryClient
-from WIPCommonPy.packet import LocationRequest, QueryRequest
+from WIPCommonPy.packet import LocationRequest, QueryRequest, QueryResponse
 
 load_dotenv()
 
@@ -274,8 +274,9 @@ class ClientAsync:
         area_code: str | int,
         *,
         proxy: bool = False,
+        raw_packet: bool = False,
         **kwargs,
-    ) -> Optional[Dict]:
+    ) -> Optional[Dict | QueryResponse]:
         if proxy:
             request = QueryRequest.create_query_request(
                 area_code=area_code,
@@ -285,11 +286,12 @@ class ClientAsync:
             )
             async with self._lock:
                 return await self._weather_client._execute_query_request_async(
-                    request=request
+                    request=request, raw_packet=raw_packet
                 )
         async with self._lock:
             return await self._query_client.get_weather_data_async(
                 area_code=area_code,
+                raw_packet=raw_packet,
                 **kwargs,
             )
 

--- a/src/WIPCommonPy/clients/weather_client.py
+++ b/src/WIPCommonPy/clients/weather_client.py
@@ -274,8 +274,16 @@ class WeatherClient:
                 self.logger.exception("Traceback:")
             return None
 
-    async def _execute_query_request_async(self, request: QueryRequest):
-        """非同期版 _execute_query_request"""
+    async def _execute_query_request_async(
+        self, request: QueryRequest, *, raw_packet: bool = False
+    ):
+        """
+        非同期版 _execute_query_request
+
+        Args:
+            request: 送信するQueryRequest
+            raw_packet: Trueの場合はパースせずにQueryResponse/ErrorResponseをそのまま返す
+        """
         try:
             start_time = time.time()
 
@@ -305,6 +313,9 @@ class WeatherClient:
                     self.logger.error("Response authentication verification failed")
                     return None
 
+                if raw_packet:
+                    return response
+
                 if response.is_success():
                     result = response.get_weather_data()
 
@@ -329,7 +340,7 @@ class WeatherClient:
                     self.logger.error(f"Error Code: {response.error_code}")
                     self.logger.error("=====================\n")
 
-                return {"type": "error", "error_code": response.error_code}
+                return response if raw_packet else {"type": "error", "error_code": response.error_code}
             else:
                 if self.debug:
                     self.logger.error(f"不明なパケットタイプ: {response_type}")


### PR DESCRIPTION
## Summary
- allow async clients to return raw QueryResponse packets with `raw_packet` flag
- propagate flag through WeatherClient and QueryClient
- fetch landmarks via `raw_packet` in FastAPI app and compute distances

## Testing
- `pytest`
- `flake8 src/WIPClientPy/client_async.py src/WIPCommonPy/clients/query_client.py src/WIPCommonPy/clients/weather_client.py python/application/map/fastapi_app.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba90fdae60832298e67b697679345a