### PR TITLE
Ensure wind flag is propagated in area-code weather requests

### DIFF
--- a/python/application/map/fastapi_app.py
+++ b/python/application/map/fastapi_app.py
@@ -641,9 +641,9 @@ async def weekly_forecast(
             packet = await call_with_metrics(
                 client.get_weather_by_area_code,
                 area_code=area_code,
-                # フラグは付けず（警報/災害フラグは不要）、
-                # サーバ側で常にlandmarksをex_fieldへ格納する実装に依存する
+                # フラグは警報/災害のみ不要。landmarks取得のためwindを明示
                 weather=True,  # 妥当性チェック上、最低1つはTrue
+                wind=True,
                 temperature=False,
                 precipitation_prob=False,
                 alert=False,

--- a/src/WIPClientPy/client_async.py
+++ b/src/WIPClientPy/client_async.py
@@ -273,10 +273,12 @@ class ClientAsync:
         self,
         area_code: str | int,
         *,
+        wind: bool = True,
         proxy: bool = False,
         raw_packet: bool = False,
         **kwargs,
     ) -> Optional[Dict | QueryResponse]:
+        kwargs.setdefault("wind", wind)
         if proxy:
             request = QueryRequest.create_query_request(
                 area_code=area_code,


### PR DESCRIPTION
## Summary
- add `wind` option with default `True` to `ClientAsync.get_weather_by_area_code`
- explicitly request wind data when fetching landmarks in FastAPI app

## Testing
- `pytest`
- `PYTHONPATH=src python python/launch_server.py --query --debug` *(fails: Connection refused to weather server)*

------
https://chatgpt.com/codex/tasks/task_e_68baec839b888322ba8aacc4b3de0156