### PR TITLE
refactor: assign landmarks via attribute

### DIFF
--- a/src/WIPServerPy/servers/query_server/modules/response_builder.py
+++ b/src/WIPServerPy/servers/query_server/modules/response_builder.py
@@ -172,7 +172,7 @@ class ResponseBuilder:
                     landmarks_json = json.dumps(best, ensure_ascii=False)
                     if self.debug:
                         print(f"Setting landmarks in ex_field: {len(landmarks_json)} bytes")
-                    response.ex_field.set("landmarks", landmarks_json)
+                    response.ex_field.landmarks = landmarks_json
         except Exception:
             # サイレントにスキップ（デバッグ時のみ標準出力）
             if self.debug:


### PR DESCRIPTION
## Summary
- assign landmarks to extended field via attribute instead of set method

## Testing
- `pytest`
- `PYTHONPATH=src python - <<'PY'
import threading, time
from WIPServerPy import QueryServer
from WIPCommonPy.clients.query_client import QueryClient
server = QueryServer(debug=True)
thread = threading.Thread(target=server.run, daemon=True)
thread.start()
time.sleep(1)
client = QueryClient(host='localhost', port=4111, debug=True, cache_enabled=False)
try:
    result = client.get_weather_data(area_code=130010, weather=True, temperature=True, precipitation_prob=True, wind=False, alert=False, disaster=False, day=0)
    print('Client received:', result)
except Exception as e:
    print('Client error:', e)
time.sleep(1)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68baec972b5c8322a38674923ef11959