### PR TITLE
Add landmarks extended field

### DIFF
--- a/Rust/deprecated/common/packet/format_spec/extended_fields.json
+++ b/Rust/deprecated/common/packet/format_spec/extended_fields.json
@@ -4,5 +4,7 @@
     "latitude": {"id": 33, "type": "float"},
     "longitude": {"id": 34, "type": "float"},
     "source": {"id": 40, "type": "str"},
-    "auth_hash": {"id": 4, "type":"str"}
+    "auth_hash": {"id": 4, "type":"str"},
+    "wind": {"id": 5, "type": "str"},
+    "landmarks": {"id": 6, "type": "str"}
 }

--- a/Rust/src/wip_common_rs/packet/format_spec/extended_fields.json
+++ b/Rust/src/wip_common_rs/packet/format_spec/extended_fields.json
@@ -4,5 +4,7 @@
     "latitude": {"id": 33, "type": "float"},
     "longitude": {"id": 34, "type": "float"},
     "source": {"id": 40, "type": "str"},
-    "auth_hash": {"id": 4, "type":"str"}
+    "auth_hash": {"id": 4, "type":"str"},
+    "wind": {"id": 5, "type": "str"},
+    "landmarks": {"id": 6, "type": "str"}
 }

--- a/cpp/include/wiplib/packet/extended_field.hpp
+++ b/cpp/include/wiplib/packet/extended_field.hpp
@@ -21,7 +21,7 @@ enum class ExtendedFieldKey : uint8_t {
     Coordinate = 3,
     AuthHash = 4,
     CustomData = 5,
-    SensorReading = 6,
+    Landmarks = 6,
     Metadata = 7,
     SourceInfo = 40,
     // 8-39 and 41-63 are reserved for future use

--- a/cpp/src/packet/extended_field.cpp
+++ b/cpp/src/packet/extended_field.cpp
@@ -225,8 +225,8 @@ ExtendedDataType ExtendedFieldProcessor::key_to_data_type(ExtendedFieldKey key) 
             return ExtendedDataType::Source;
         case ExtendedFieldKey::CustomData:
             return ExtendedDataType::Binary;
-        case ExtendedFieldKey::SensorReading:
-            return ExtendedDataType::Float32;
+        case ExtendedFieldKey::Landmarks:
+            return ExtendedDataType::Json;
         case ExtendedFieldKey::Metadata:
             return ExtendedDataType::Json;
         default:

--- a/cpp/src/packet/format_spec/extended_fields.json
+++ b/cpp/src/packet/format_spec/extended_fields.json
@@ -51,9 +51,10 @@
     },
     {
       "key": 6,
-      "name": "sensor_reading",
-      "type": "float32",
-      "description": "Sensor measurement value"
+      "name": "landmarks",
+      "type": "json",
+      "description": "Landmark information",
+      "encoding": "utf8"
     },
     {
       "key": 7,

--- a/src/WIPCommonPy/packet/format_spec/extended_fields.json
+++ b/src/WIPCommonPy/packet/format_spec/extended_fields.json
@@ -5,5 +5,6 @@
     "longitude": {"id": 34, "type": "float"},
     "source": {"id": 40, "type": "str"},
     "auth_hash": {"id": 4, "type":"str"},
-    "wind": {"id": 5, "type": "str"}
+    "wind": {"id": 5, "type": "str"},
+    "landmarks": {"id": 6, "type": "str"}
 }


### PR DESCRIPTION
## Summary
- add `landmarks` extended field (ID 6) across Python, Rust, and C++ specs
- update C++ extended field enum and type mapping

## Testing
- `PYTHONPATH=src python -m pytest`
- `g++ -std=c++20 -Icpp/include -c cpp/src/packet/extended_field.cpp -o /tmp/extended_field.o`
- `cargo test` *(fails: stack overflow in wip_rust tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bb79390c608322a92a197ab7c05ae5