### PR TITLE
Add landmarks option for weather queries

### DIFF
--- a/src/WIPClientPy/client_async.py
+++ b/src/WIPClientPy/client_async.py
@@ -139,6 +139,7 @@ class ClientAsync:
         temperature: bool = True,
         precipitation_prob: bool = True,
         wind: bool = False,
+        landmarks: bool = False,
         alert: bool = False,
         disaster: bool = False,
         day: int = 0,
@@ -162,6 +163,7 @@ class ClientAsync:
                     weather=weather,
                     temperature=temperature,
                     precipitation_prob=precipitation_prob,
+                    landmarks=landmarks,
                     alert=alert,
                     disaster=disaster,
                     day=day,
@@ -179,6 +181,7 @@ class ClientAsync:
                     weather=weather,
                     temperature=temperature,
                     precipitation_prob=precipitation_prob,
+                    landmarks=landmarks,
                     alert=alert,
                     disaster=disaster,
                     day=day,
@@ -197,6 +200,7 @@ class ClientAsync:
                         temperature=temperature,
                         precipitation_prob=precipitation_prob,
                         wind=wind,
+                        landmarks=landmarks,
                         alert=alert,
                         disaster=disaster,
                         day=day,
@@ -210,6 +214,7 @@ class ClientAsync:
                         temperature=temperature,
                         precipitation_prob=precipitation_prob,
                         wind=wind,
+                        landmarks=landmarks,
                         alert=alert,
                         disaster=disaster,
                         day=day,
@@ -224,6 +229,7 @@ class ClientAsync:
                         temperature=temperature,
                         precipitation_prob=precipitation_prob,
                         wind=wind,
+                        landmarks=landmarks,
                         alert=alert,
                         disaster=disaster,
                         day=day,
@@ -239,6 +245,7 @@ class ClientAsync:
         longitude: float,
         *,
         proxy: bool = False,
+        landmarks: bool = False,
         **kwargs,
     ) -> Optional[Dict]:
         if proxy:
@@ -247,6 +254,7 @@ class ClientAsync:
                 longitude=longitude,
                 packet_id=self._weather_client.PIDG.next_id(),
                 version=self._weather_client.VERSION,
+                landmarks=landmarks,
                 **kwargs,
             )
             async with self._lock:
@@ -257,6 +265,7 @@ class ClientAsync:
             loc_resp, _ = await self._location_client.get_location_data_async(
                 latitude=latitude,
                 longitude=longitude,
+                landmarks=landmarks,
             )
         if not loc_resp or not loc_resp.is_valid():
             return None
@@ -264,6 +273,7 @@ class ClientAsync:
         async with self._lock:
             return await self._query_client.get_weather_data_async(
                 area_code=area_code,
+                landmarks=landmarks,
                 **kwargs,
             )
 
@@ -272,6 +282,7 @@ class ClientAsync:
         area_code: str | int,
         *,
         proxy: bool = False,
+        landmarks: bool = False,
         **kwargs,
     ) -> Optional[Dict]:
         if proxy:
@@ -279,6 +290,7 @@ class ClientAsync:
                 area_code=area_code,
                 packet_id=self._weather_client.PIDG.next_id(),
                 version=self._weather_client.VERSION,
+                landmarks=landmarks,
                 **kwargs,
             )
             async with self._lock:
@@ -288,6 +300,7 @@ class ClientAsync:
         async with self._lock:
             return await self._query_client.get_weather_data_async(
                 area_code=area_code,
+                landmarks=landmarks,
                 **kwargs,
             )
 

--- a/src/WIPCommonPy/clients/query_client.py
+++ b/src/WIPCommonPy/clients/query_client.py
@@ -160,6 +160,7 @@ class QueryClient:
         precipitation_prob,
         alert,
         disaster,
+        landmarks,
         day=0,
     ):
         """
@@ -172,13 +173,17 @@ class QueryClient:
             precipitation_prob: 降水確率データフラグ
             alert: 警報データフラグ
             disaster: 災害データフラグ
+            landmarks: ランドマークデータフラグ
             day: 日数
 
         Returns:
             str: キャッシュキー
         """
         # 各フラグを文字列化してキーに含める
-        flags = f"w{int(weather)}t{int(temperature)}p{int(precipitation_prob)}a{int(alert)}d{int(disaster)}"
+        flags = (
+            f"w{int(weather)}t{int(temperature)}p{int(precipitation_prob)}"
+            f"a{int(alert)}d{int(disaster)}l{int(landmarks)}"
+        )
         return f"query:{area_code}:{flags}:d{day}"
 
     def _create_cached_response(self, cached_data, area_code):
@@ -212,6 +217,7 @@ class QueryClient:
         wind=False,
         alert=False,
         disaster=False,
+        landmarks=False,
         source=None,
         timeout=5.0,
         use_cache=True,
@@ -228,6 +234,7 @@ class QueryClient:
             precipitation_prob: 降水確率データを取得するか
             alert: 警報データを取得するか
             disaster: 災害情報データを取得するか
+            landmarks: ランドマークデータを取得するか
             source: 送信元情報 (ip, port) のタプル
             timeout: タイムアウト時間（秒）
             use_cache: キャッシュを使用するかどうか
@@ -252,6 +259,7 @@ class QueryClient:
                     precipitation_prob,
                     alert,
                     disaster,
+                    landmarks,
                     day,
                 )
                 cached_data = self.cache.get(cache_key)
@@ -278,6 +286,7 @@ class QueryClient:
                 temperature=temperature,
                 precipitation_prob=precipitation_prob,
                 wind=wind,
+                landmarks=landmarks,
                 alert=alert,
                 disaster=disaster,
                 source=source,
@@ -334,6 +343,7 @@ class QueryClient:
                         precipitation_prob,
                         alert,
                         disaster,
+                        landmarks,
                         day,
                     )
                     # タイミング情報を除いてキャッシュに保存
@@ -391,6 +401,7 @@ class QueryClient:
         wind=False,
         alert=False,
         disaster=False,
+        landmarks=False,
         source=None,
         timeout=5.0,
         use_cache=True,
@@ -412,6 +423,7 @@ class QueryClient:
                     precipitation_prob,
                     alert,
                     disaster,
+                    landmarks,
                     day,
                 )
                 cached_data = self.cache.get(cache_key)
@@ -438,6 +450,7 @@ class QueryClient:
                 temperature=temperature,
                 precipitation_prob=precipitation_prob,
                 wind=wind,
+                landmarks=landmarks,
                 alert=alert,
                 disaster=disaster,
                 source=source,
@@ -489,6 +502,7 @@ class QueryClient:
                         precipitation_prob,
                         alert,
                         disaster,
+                        landmarks,
                         day,
                     )
                     cache_data = {k: v for k, v in result.items() if k != "timing"}


### PR DESCRIPTION
## Summary
- allow QueryRequest and QueryClient to request landmark data
- propagate `landmarks` option through async client API and cache keys

## Testing
- `python -m py_compile src/WIPCommonPy/packet/types/query_packet.py src/WIPCommonPy/clients/query_client.py src/WIPClientPy/client_async.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb79424458832289355dd55e429b94