### PR TITLE
ランドマーク取得処理のAPIレスポンス対応

### DIFF
--- a/python/application/map/fastapi_app.py
+++ b/python/application/map/fastapi_app.py
@@ -467,7 +467,7 @@ async def get_landmarks(
 
     try:
         # 座標からエリアコードを取得（天気データも一緒に取得）
-        weather_data = await call_with_metrics(
+        today_weather = await call_with_metrics(
             client.get_weather_by_coordinates,
             lat,
             lng,
@@ -477,122 +477,85 @@ async def get_landmarks(
             wind=True,
             alert=True,
             disaster=True,
+            landmarks=True,
             day=0,
             ip=ip,
             context={"coords": f"{lat},{lng}", "purpose": "landmarks"},
         )
-        
-        if not weather_data or isinstance(weather_data, dict) and ("error" in weather_data or "error_code" in weather_data):
+
+        if not today_weather or isinstance(today_weather, dict) and ("error" in today_weather or "error_code" in today_weather):
             return JSONResponse(
                 {"status": "error", "message": "エリアコードの取得に失敗しました"},
                 status_code=500,
             )
 
-        area_code = weather_data.get("area_code")
+        area_code = today_weather.get("area_code")
         if not area_code:
             return JSONResponse(
                 {"status": "error", "message": "エリアコードの取得に失敗しました"},
                 status_code=500,
             )
 
-        # RedisJSONから直接ランドマークデータを取得
         try:
-            import redis
-            import json as json_lib
             import math
 
             def calculate_distance(lat1, lng1, lat2, lng2):
                 """2つの座標間の距離をkmで計算（Haversine公式）"""
                 R = 6371  # 地球の半径（km）
-                
-                # 度をラジアンに変換
                 lat1_rad = math.radians(lat1)
                 lng1_rad = math.radians(lng1)
                 lat2_rad = math.radians(lat2)
                 lng2_rad = math.radians(lng2)
-                
-                # Haversine公式
                 dlat = lat2_rad - lat1_rad
                 dlng = lng2_rad - lng1_rad
-                
-                a = (math.sin(dlat/2) * math.sin(dlat/2) +
-                     math.cos(lat1_rad) * math.cos(lat2_rad) *
-                     math.sin(dlng/2) * math.sin(dlng/2))
-                c = 2 * math.atan2(math.sqrt(a), math.sqrt(1-a))
+                a = (
+                    math.sin(dlat / 2) * math.sin(dlat / 2)
+                    + math.cos(lat1_rad)
+                    * math.cos(lat2_rad)
+                    * math.sin(dlng / 2)
+                    * math.sin(dlng / 2)
+                )
+                c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
                 distance = R * c
-                
                 return round(distance * 10) / 10  # 小数点第1位まで
-            
-            # 環境変数から接続設定・キー接頭辞を取得
-            import os as _os
-            _host = _os.getenv("REDIS_HOST", "localhost")
-            _port = int(_os.getenv("REDIS_PORT", 6379))
-            _db = int(_os.getenv("REDIS_DB", 0))
-            _prefix = _os.getenv("REPORT_DB_KEY_PREFIX", _os.getenv("REDIS_KEY_PREFIX", "")) or ""
 
-            redis_client = redis.Redis(host=_host, port=_port, db=_db, decode_responses=True)
-            redis_key = f"{_prefix}weather:{area_code}"
+            raw_landmarks = today_weather.get("landmarks", [])
+            area_name = today_weather.get("area_name", "不明")
+            landmarks_with_distance = []
+            for landmark in raw_landmarks:
+                if "latitude" in landmark and "longitude" in landmark:
+                    distance = calculate_distance(
+                        lat, lng, landmark["latitude"], landmark["longitude"]
+                    )
+                    item = landmark.copy()
+                    item["distance"] = distance
+                    landmarks_with_distance.append(item)
 
-            # RedisJSON もしくは通常キーの両対応で取得
-            weather_info = None
-            try:
-                redis_data = redis_client.execute_command('JSON.GET', redis_key)
-                if redis_data:
-                    weather_info = json_lib.loads(redis_data)
-            except Exception:
-                pass
-            if weather_info is None:
-                raw = redis_client.get(redis_key)
-                if raw:
-                    try:
-                        weather_info = json_lib.loads(raw)
-                    except Exception:
-                        weather_info = None
+            landmarks_with_distance.sort(key=lambda x: x.get("distance", float("inf")))
+            MAX_LANDMARKS = int(os.getenv("LANDMARKS_TOPN", "100"))
+            if len(landmarks_with_distance) > MAX_LANDMARKS:
+                landmarks_with_distance = landmarks_with_distance[:MAX_LANDMARKS]
 
-            if weather_info:
-                raw_landmarks = weather_info.get("landmarks", [])
-                area_name = weather_info.get("area_name", "不明")
-                
-                # 各ランドマークに距離を計算して追加
-                landmarks_with_distance = []
-                for landmark in raw_landmarks:
-                    if 'latitude' in landmark and 'longitude' in landmark:
-                        distance = calculate_distance(
-                            lat, lng,
-                            landmark['latitude'], landmark['longitude']
-                        )
-                        landmark_with_distance = landmark.copy()
-                        landmark_with_distance['distance'] = distance
-                        landmarks_with_distance.append(landmark_with_distance)
-                
-                # 距離順でソート
-                landmarks_with_distance.sort(key=lambda x: x.get('distance', float('inf')))
-                
-                return JSONResponse({
+            return JSONResponse(
+                {
                     "status": "ok",
                     "coordinates": {"lat": lat, "lng": lng},
                     "area_code": area_code,
                     "area_name": area_name,
                     "landmarks": landmarks_with_distance,
-                })
-            else:
-                return JSONResponse({
+                }
+            )
+        except Exception as e:
+            logger.error(f"Error processing landmarks: {e}")
+            return JSONResponse(
+                {
                     "status": "ok",
                     "coordinates": {"lat": lat, "lng": lng},
                     "area_code": area_code,
                     "area_name": "不明",
                     "landmarks": [],
-                })
-            
-        except Exception as e:
-            logger.error(f"Error getting landmarks from Redis: {e}")
-            return JSONResponse({
-                "status": "ok",
-                "coordinates": {"lat": lat, "lng": lng},
-                "area_code": area_code,
-                "area_name": "不明",
-                "landmarks": [],
-            })
+                }
+            )
 
     except Exception as e:
         logger.error(f"Error in get_landmarks: {e}")
@@ -632,6 +595,7 @@ async def weekly_forecast(
             wind=True,
             alert=True,
             disaster=True,
+            landmarks=True,
             day=0,
             ip=ip,
             context={"coords": f"{lat},{lng}", "day": 0},
@@ -661,6 +625,7 @@ async def weekly_forecast(
                     "wind": True,
                     "alert": True,
                     "disaster": True,
+                    "landmarks": False,
                 }
                 weather_data = await call_with_metrics(
                     client.get_weather_by_area_code,
@@ -762,17 +727,15 @@ async def weekly_forecast(
                   logger.error(f"Error fetching wind data from Redis for today: {e}")
           
           weekly_forecast_list = [_add_date_info(today_with_wind, 0)] + results
-          weekly_forecast_list = sorted(weekly_forecast_list, key=lambda x: x["day"])
-          _set_cached_weekly(area_code, weekly_forecast_list)
+        weekly_forecast_list = sorted(weekly_forecast_list, key=lambda x: x["day"])
+        _set_cached_weekly(area_code, weekly_forecast_list)
 
         # 追加: ランドマークを同梱して1リクエスト化
-        area_name: str = "不明"
+        area_name: str = today_weather.get("area_name", "不明")
+        raw_landmarks = today_weather.get("landmarks", [])
         landmarks_with_distance = []
         try:
-            import redis
-            import json as json_lib
             import math
-            import os as _os
 
             def calculate_distance(lat1, lng1, lat2, lng2):
                 R = 6371
@@ -792,49 +755,21 @@ async def weekly_forecast(
                 c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
                 return round((R * c) * 10) / 10
 
-            _host = _os.getenv("REDIS_HOST", "localhost")
-            _port = int(_os.getenv("REDIS_PORT", 6379))
-            _db = int(_os.getenv("REDIS_DB", 0))
-            _prefix = _os.getenv("REPORT_DB_KEY_PREFIX", _os.getenv("REDIS_KEY_PREFIX", "")) or ""
+            for landmark in raw_landmarks:
+                if "latitude" in landmark and "longitude" in landmark:
+                    distance = calculate_distance(
+                        lat, lng, landmark["latitude"], landmark["longitude"]
+                    )
+                    item = landmark.copy()
+                    item["distance"] = distance
+                    landmarks_with_distance.append(item)
 
-            redis_client = redis.Redis(host=_host, port=_port, db=_db, decode_responses=True)
-            redis_key = f"{_prefix}weather:{area_code}"
-
-            weather_info = None
-            try:
-                redis_data = redis_client.execute_command("JSON.GET", redis_key)
-                if redis_data:
-                    weather_info = json_lib.loads(redis_data)
-            except Exception:
-                pass
-            if weather_info is None:
-                raw = redis_client.get(redis_key)
-                if raw:
-                    try:
-                        weather_info = json_lib.loads(raw)
-                    except Exception:
-                        weather_info = None
-
-            if weather_info:
-                raw_landmarks = weather_info.get("landmarks", [])
-                area_name = weather_info.get("area_name", "不明")
-
-                for landmark in raw_landmarks:
-                    if "latitude" in landmark and "longitude" in landmark:
-                        distance = calculate_distance(
-                            lat, lng, landmark["latitude"], landmark["longitude"]
-                        )
-                        item = landmark.copy()
-                        item["distance"] = distance
-                        landmarks_with_distance.append(item)
-
-                landmarks_with_distance.sort(
-                    key=lambda x: x.get("distance", float("inf"))
-                )
-                # 近傍上位N件のみを返却（転送/描画コストを抑制）
-                MAX_LANDMARKS = int(os.getenv("LANDMARKS_TOPN", "100"))
-                if len(landmarks_with_distance) > MAX_LANDMARKS:
-                    landmarks_with_distance = landmarks_with_distance[:MAX_LANDMARKS]
+            landmarks_with_distance.sort(
+                key=lambda x: x.get("distance", float("inf"))
+            )
+            MAX_LANDMARKS = int(os.getenv("LANDMARKS_TOPN", "100"))
+            if len(landmarks_with_distance) > MAX_LANDMARKS:
+                landmarks_with_distance = landmarks_with_distance[:MAX_LANDMARKS]
         except Exception as e:  # pragma: no cover
             logger.error(f"Error embedding landmarks in weekly_forecast: {e}")
 


### PR DESCRIPTION
## 概要
- `/landmarks` エンドポイントで `get_weather_by_coordinates` に `landmarks=True` を指定し、WIP から受け取ったランドマーク情報を距離付きで返却
- `/weekly_forecast` でも `landmarks` フラグを調整し、Redis を介さず WIP レスポンスのランドマークを利用

## テスト
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb7953977c83229c83771be2275d47